### PR TITLE
Removing the master and slave vocabulary

### DIFF
--- a/src/build/android/pylib/perf/test_runner.py
+++ b/src/build/android/pylib/perf/test_runner.py
@@ -4,7 +4,7 @@
 
 """Runs perf tests.
 
-Our buildbot infrastructure requires each slave to run steps serially.
+Our buildbot infrastructure requires each subordinate to run steps serially.
 This is sub-optimal for android, where these steps can run independently on
 multiple connected devices.
 
@@ -69,13 +69,13 @@ from pylib.base import base_test_result
 from pylib.base import base_test_runner
 
 
-# Regex for the master branch commit position.
-_GIT_CR_POS_RE = re.compile(r'^Cr-Commit-Position: refs/heads/master@{#(\d+)}$')
+# Regex for the main branch commit position.
+_GIT_CR_POS_RE = re.compile(r'^Cr-Commit-Position: refs/heads/main@{#(\d+)}$')
 
 
 def _GetChromiumRevision():
   # pylint: disable=line-too-long
-  """Get the git hash and commit position of the chromium master branch.
+  """Get the git hash and commit position of the chromium main branch.
 
   See: https://chromium.googlesource.com/chromium/tools/build/+/master/scripts/slave/runtest.py#212
 
@@ -415,7 +415,7 @@ class TestRunner(base_test_runner.BaseTestRunner):
     else:
       result_type = base_test_result.ResultType.FAIL
       # Since perf tests use device affinity, give the device a chance to
-      # recover if it is offline after a failure. Otherwise, the master sharder
+      # recover if it is offline after a failure. Otherwise, the main sharder
       # will remove it from the pool and future tests on this device will fail.
       try:
         self.device.WaitUntilFullyBooted(timeout=120)

--- a/src/build/android/pylib/results/flakiness_dashboard/json_results_generator.py
+++ b/src/build/android/pylib/results/flakiness_dashboard/json_results_generator.py
@@ -159,7 +159,7 @@ class JSONResultsGeneratorBase(object):
 
   # line too long pylint: disable=line-too-long
   URL_FOR_TEST_LIST_JSON = (
-      'http://%s/testfile?builder=%s&name=%s&testlistjson=1&testtype=%s&master=%s')
+      'http://%s/testfile?builder=%s&name=%s&testlistjson=1&testtype=%s&main=%s')
   # pylint: enable=line-too-long
 
   def __init__(self, builder_name, build_name, build_number,
@@ -167,7 +167,7 @@ class JSONResultsGeneratorBase(object):
                test_results_map, svn_repositories=None,
                test_results_server=None,
                test_type='',
-               master_name=''):
+               main_name=''):
     """Modifies the results.json file. Grabs it off the archive directory
     if it is not found locally.
 
@@ -185,7 +185,7 @@ class JSONResultsGeneratorBase(object):
           included in the JSON with the given json_field_name.
       test_results_server: server that hosts test results json.
       test_type: test type string (e.g. 'layout-tests').
-      master_name: the name of the buildbot master.
+      main_name: the name of the buildbot main.
     """
     self._builder_name = builder_name
     self._build_name = build_name
@@ -202,7 +202,7 @@ class JSONResultsGeneratorBase(object):
 
     self._test_results_server = test_results_server
     self._test_type = test_type
-    self._master_name = master_name
+    self._main_name = main_name
 
     self._archived_results = None
 
@@ -272,16 +272,16 @@ class JSONResultsGeneratorBase(object):
     if not self._test_results_server:
       return
 
-    if not self._master_name:
+    if not self._main_name:
       _log.error(
-          '--test-results-server was set, but --master-name was not.  Not '
+          '--test-results-server was set, but --main-name was not.  Not '
           'uploading JSON files.')
       return
 
     _log.info('Uploading JSON files for builder: %s', self._builder_name)
     attrs = [('builder', self._builder_name),
              ('testtype', self._test_type),
-             ('master', self._master_name)]
+             ('main', self._main_name)]
 
     files = [(json_file, os.path.join(self._results_directory, json_file))
              for json_file in json_files]
@@ -377,7 +377,7 @@ class JSONResultsGeneratorBase(object):
                          urllib2.quote(self._builder_name),
                          self.RESULTS_FILENAME,
                          urllib2.quote(self._test_type),
-                         urllib2.quote(self._master_name)))
+                         urllib2.quote(self._main_name)))
 
     try:
       # FIXME: We should talk to the network via a Host object.

--- a/src/build/android/pylib/results/flakiness_dashboard/results_uploader.py
+++ b/src/build/android/pylib/results/flakiness_dashboard/results_uploader.py
@@ -24,7 +24,7 @@ class JSONResultsGenerator(json_results_generator.JSONResultsGeneratorBase):
   the test results server.
   """
   def __init__(self, builder_name, build_name, build_number, tmp_folder,
-               test_results_map, test_results_server, test_type, master_name):
+               test_results_map, test_results_server, test_type, main_name):
     super(JSONResultsGenerator, self).__init__(
         builder_name=builder_name,
         build_name=build_name,
@@ -36,7 +36,7 @@ class JSONResultsGenerator(json_results_generator.JSONResultsGeneratorBase):
                           ('chrome', '.')),
         test_results_server=test_results_server,
         test_type=test_type,
-        master_name=master_name)
+        main_name=main_name)
 
   #override
   def _GetModifierChar(self, test_name):
@@ -96,20 +96,20 @@ class ResultsUploader(object):
     upstream = (tests_type != 'Chromium_Android_Instrumentation')
     if upstream:
       # TODO(frankf): Use factory properties (see buildbot/bb_device_steps.py)
-      # This requires passing the actual master name (e.g. 'ChromiumFYI' not
+      # This requires passing the actual main name (e.g. 'ChromiumFYI' not
       # 'chromium.fyi').
-      from slave import slave_utils # pylint: disable=F0401
-      self._build_name = slave_utils.SlaveBuildName(constants.DIR_SOURCE_ROOT)
-      self._master_name = slave_utils.GetActiveMaster()
+      from subordinate import subordinate_utils # pylint: disable=F0401
+      self._build_name = subordinate_utils.SubordinateBuildName(constants.DIR_SOURCE_ROOT)
+      self._main_name = subordinate_utils.GetActiveMain()
     else:
       self._build_name = 'chromium-android'
       buildbot_branch = os.environ.get('BUILDBOT_BRANCH')
       if not buildbot_branch:
-        buildbot_branch = 'master'
+        buildbot_branch = 'main'
       else:
         # Ensure there's no leading "origin/"
         buildbot_branch = buildbot_branch[buildbot_branch.find('/') + 1:]
-      self._master_name = '%s-%s' % (self._build_name, buildbot_branch)
+      self._main_name = '%s-%s' % (self._build_name, buildbot_branch)
 
     self._test_results_map = {}
 
@@ -156,7 +156,7 @@ class ResultsUploader(object):
           test_results_map=self._test_results_map,
           test_results_server=test_results_server,
           test_type=self._tests_type,
-          master_name=self._master_name)
+          main_name=self._main_name)
 
       json_files = ["incremental_results.json", "times_ms.json"]
       results_generator.GenerateJSONOutput()

--- a/src/content/test/gpu/run_gpu_test.py
+++ b/src/content/test/gpu/run_gpu_test.py
@@ -39,8 +39,8 @@ def _LaunchDBus():
 
   # Only start DBus on systems that are actually running X. Using DISPLAY
   # variable is not reliable, because is it set by the /etc/init.d/buildbot
-  # script for all slaves.
-  # TODO(sergiyb): When all GPU slaves are migrated to swarming, we can remove
+  # script for all subordinates.
+  # TODO(sergiyb): When all GPU subordinates are migrated to swarming, we can remove
   # assignment of the DISPLAY from /etc/init.d/buildbot because this hack was
   # used to run GPU tests on buildbot. After it is removed, we can use DISPLAY
   # variable here to check if we are running X.

--- a/src/third_party/catapult/base/util/perfbot_stats/chrome_perf_stats.py
+++ b/src/third_party/catapult/base/util/perfbot_stats/chrome_perf_stats.py
@@ -22,7 +22,7 @@ import urllib
 import urllib2
 
 BUILDER_LIST_URL = ('https://chrome-infra-stats.appspot.com/'
-                    '_ah/api/stats/v1/masters/chromium.perf')
+                    '_ah/api/stats/v1/mains/chromium.perf')
 
 BUILDER_STATS_URL = ('https://chrome-infra-stats.appspot.com/_ah/api/stats/v1/'
                      'stats/chromium.perf/%s/overall__build__result__/%s')
@@ -105,7 +105,7 @@ def UploadToPerfDashboard(success_rates):
     date_str = ('%s-%s-%s' %
         (success_rate[0][0:4], success_rate[0][4:6], success_rate[0][6:8]))
     dashboard_data = {
-        'master': 'WaterfallStats',
+        'main': 'WaterfallStats',
         'bot': 'ChromiumPerf',
         'point_id': int(success_rate[0]),
         'supplemental': {},

--- a/src/third_party/catapult/base/util/perfbot_stats/chrome_perf_step_timings.py
+++ b/src/third_party/catapult/base/util/perfbot_stats/chrome_perf_step_timings.py
@@ -23,7 +23,7 @@ from dateutil import parser as dateparser
 from datetime import datetime, timedelta
 
 BUILDER_STEPS_URL = ('https://chrome-infra-stats.appspot.com/_ah/api/stats/v1/'
-                     'masters/chromium.perf/%s')
+                     'mains/chromium.perf/%s')
 
 STEP_ACTIVE_URL = ('https://chrome-infra-stats.appspot.com/_ah/api/stats/v1/'
                    'steps/last/chromium.perf/%s/%s/1')

--- a/src/third_party/catapult/catapult_build/appengine_deploy.py
+++ b/src/third_party/catapult/catapult_build/appengine_deploy.py
@@ -41,7 +41,7 @@ def AppcfgUpdate(paths, app_id):
 
 
 def _VersionName():
-  is_synced = not _Run(['git', 'diff', 'master']).strip()
+  is_synced = not _Run(['git', 'diff', 'main']).strip()
   deployment_type = 'clean' if is_synced else 'dev'
   email = _Run(['git', 'config', '--get', 'user.email'])
   username = email[0:email.find('@')]

--- a/src/third_party/catapult/dashboard/dashboard/add_point.py
+++ b/src/third_party/catapult/dashboard/dashboard/add_point.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-"""URL endpoint to allow Buildbot slaves to post data to the dashboard."""
+"""URL endpoint to allow Buildbot subordinates to post data to the dashboard."""
 
 import copy
 import json
@@ -58,7 +58,7 @@ class AddPointHandler(post_data_handler.PostDataHandler):
 
       [
         {
-          "master": "ChromiumPerf",
+          "main": "ChromiumPerf",
           "bot": "xp-release-dual-core",
           "test": "dromaeo/dom/modify",
           "revision": 123456789,
@@ -76,7 +76,7 @@ class AddPointHandler(post_data_handler.PostDataHandler):
         ...
       ]
 
-    In general, the required fields are "master", "bot", "test" (which together
+    In general, the required fields are "main", "bot", "test" (which together
     form the test path which identifies the series that this point belongs to),
     and "revision" and "value", which are the X and Y values for the point.
 
@@ -90,7 +90,7 @@ class AddPointHandler(post_data_handler.PostDataHandler):
     v0).
 
     {
-      "master": "ChromiumPerf",
+      "main": "ChromiumPerf",
       <other row fields>,
       "chart_data": {
         "foo": {
@@ -175,9 +175,9 @@ class AddPointHandler(post_data_handler.PostDataHandler):
     """
     assert type(dash_json_dict) is dict
     # A Dashboard JSON dict should at least have all charts coming from the
-    # same master, bot and rev. It can contain multiple charts, however.
-    if not dash_json_dict.get('master'):
-      raise BadRequestError('No master name given.')
+    # same main, bot and rev. It can contain multiple charts, however.
+    if not dash_json_dict.get('main'):
+      raise BadRequestError('No main name given.')
     if not dash_json_dict.get('bot'):
       raise BadRequestError('No bot name given.')
     if not dash_json_dict.get('point_id'):
@@ -249,7 +249,7 @@ def _MakeRowTemplate(dash_json_dict):
   """Produces a template for rows created from a Dashboard JSON v1.0 dict.
 
   _DashboardJsonToRawRows adds metadata fields to every row that it creates.
-  These include things like master, bot, point ID, versions, and other
+  These include things like main, bot, point ID, versions, and other
   supplementary data. This method produces a dict containing this metadata
   to which row-specific information (like value and error) can be added.
   Some metadata needs to be transformed to conform to the v0 format, and this
@@ -478,9 +478,9 @@ def _ConstructTestPathMap(row_dicts):
   """Makes a mapping from test paths to last added revision."""
   last_added_revision_keys = []
   for row in row_dicts:
-    if not ('master' in row and 'bot' in row and 'test' in row):
+    if not ('main' in row and 'bot' in row and 'test' in row):
       continue
-    path = '%s/%s/%s' % (row['master'], row['bot'], row['test'].strip('/'))
+    path = '%s/%s/%s' % (row['main'], row['bot'], row['test'].strip('/'))
     if len(path) > _MAX_TESTPATH_LENGTH:
       continue
     last_added_revision_keys.append(ndb.Key('LastAddedRevision', path))
@@ -507,17 +507,17 @@ def _ValidateRowDict(row, test_map):
   Raises:
     BadRequestError: The input was not valid.
   """
-  required_fields = ['master', 'bot', 'test']
+  required_fields = ['main', 'bot', 'test']
   for field in required_fields:
     if field not in row:
       raise BadRequestError('No "%s" field in row dict.' % field)
-  _ValidateMasterBotTest(row['master'], row['bot'], row['test'])
+  _ValidateMainBotTest(row['main'], row['bot'], row['test'])
   _ValidateRowId(row, test_map)
   GetAndValidateRowProperties(row)
 
 
-def _ValidateMasterBotTest(master, bot, test):
-  """Validates the master, bot, and test properties of a row dict."""
+def _ValidateMainBotTest(main, bot, test):
+  """Validates the main, bot, and test properties of a row dict."""
   # Trailing and leading slashes in the test name are ignored.
   # The test name must consist of at least a test suite plus sub-test.
   test = test.strip('/')
@@ -527,11 +527,11 @@ def _ValidateMasterBotTest(master, bot, test):
   if len(test.split('/')) > graph_data.MAX_TEST_ANCESTORS:
     raise BadRequestError('Invalid test name: %s' % test)
 
-  # The master and bot names have just one part.
-  if '/' in master or '/' in bot:
-    raise BadRequestError('Illegal slash in master or bot name.')
+  # The main and bot names have just one part.
+  if '/' in main or '/' in bot:
+    raise BadRequestError('Illegal slash in main or bot name.')
 
-  _ValidateTestPath('%s/%s/%s' % (master, bot, test))
+  _ValidateTestPath('%s/%s/%s' % (main, bot, test))
 
 
 def _ValidateTestPath(test_path):
@@ -550,7 +550,7 @@ def _ValidateTestPath(test_path):
 
 
 def _ValidateTestPathPartName(name):
-  """Checks whether a Master, Bot or Test name is OK."""
+  """Checks whether a Main, Bot or Test name is OK."""
   # NDB Datastore doesn't allow key names to start and with "__" and "__".
   if name.startswith('__') and name.endswith('__'):
     raise BadRequestError(
@@ -571,8 +571,8 @@ def _ValidateRowId(row_dict, test_map):
   row_id = GetAndValidateRowId(row_dict)
 
   # Get the last added revision number for this test.
-  master, bot, test = row_dict['master'], row_dict['bot'], row_dict['test']
-  test_path = '%s/%s/%s' % (master, bot, test)
+  main, bot, test = row_dict['main'], row_dict['bot'], row_dict['test']
+  test_path = '%s/%s/%s' % (main, bot, test)
   last_row_id = test_map.get(test_path)
   if not last_row_id:
     # Could be first point in test.

--- a/src/third_party/catapult/dashboard/dashboard/add_point_queue_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/add_point_queue_test.py
@@ -18,8 +18,8 @@ class GetOrCreateAncestorsTest(testing_common.TestCase):
     self.SetCurrentUser('foo@bar.com', is_admin=True)
 
   def testGetOrCreateAncestors_GetsExistingEntities(self):
-    master_key = graph_data.Master(id='ChromiumPerf', parent=None).put()
-    bot_key = graph_data.Bot(id='win7', parent=master_key).put()
+    main_key = graph_data.Main(id='ChromiumPerf', parent=None).put()
+    bot_key = graph_data.Bot(id='win7', parent=main_key).put()
     suite_key = graph_data.Test(id='dromaeo', parent=bot_key).put()
     subtest_key = graph_data.Test(id='dom', parent=suite_key).put()
     graph_data.Test(id='modify', parent=subtest_key).put()
@@ -28,7 +28,7 @@ class GetOrCreateAncestorsTest(testing_common.TestCase):
     self.assertEqual('modify', actual_parent.key.id())
     # No extra Test or Bot objects should have been added to the database
     # beyond the four that were put in before the _GetOrCreateAncestors call.
-    self.assertEqual(1, len(graph_data.Master.query().fetch()))
+    self.assertEqual(1, len(graph_data.Main.query().fetch()))
     self.assertEqual(1, len(graph_data.Bot.query().fetch()))
     self.assertEqual(3, len(graph_data.Test.query().fetch()))
 
@@ -37,14 +37,14 @@ class GetOrCreateAncestorsTest(testing_common.TestCase):
         'ChromiumPerf', 'win7', 'dromaeo/dom/modify')
     self.assertEqual('modify', parent.key.id())
     # Check that all the Bot and Test entities were correctly added.
-    created_masters = graph_data.Master.query().fetch()
+    created_mains = graph_data.Main.query().fetch()
     created_bots = graph_data.Bot.query().fetch()
     created_tests = graph_data.Test.query().fetch()
-    self.assertEqual(1, len(created_masters))
+    self.assertEqual(1, len(created_mains))
     self.assertEqual(1, len(created_bots))
     self.assertEqual(3, len(created_tests))
-    self.assertEqual('ChromiumPerf', created_masters[0].key.id())
-    self.assertIsNone(created_masters[0].key.parent())
+    self.assertEqual('ChromiumPerf', created_mains[0].key.id())
+    self.assertIsNone(created_mains[0].key.parent())
     self.assertEqual('win7', created_bots[0].key.id())
     self.assertEqual('ChromiumPerf', created_bots[0].key.parent().id())
     self.assertEqual('dromaeo', created_tests[0].key.id())

--- a/src/third_party/catapult/dashboard/dashboard/add_point_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/add_point_test.py
@@ -30,7 +30,7 @@ _FETCH_LIMIT = 100
 
 # Sample point which contains all of the required fields.
 _SAMPLE_POINT = {
-    'master': 'ChromiumPerf',
+    'main': 'ChromiumPerf',
     'bot': 'win7',
     'test': 'my_test_suite/my_test',
     'revision': 12345,
@@ -39,7 +39,7 @@ _SAMPLE_POINT = {
 
 # Sample Dashboard JSON v1.0 point.
 _SAMPLE_DASHBOARD_JSON = {
-    'master': 'ChromiumPerf',
+    'main': 'ChromiumPerf',
     'bot': 'win7',
     'point_id': '12345',
     'supplemental': {
@@ -69,7 +69,7 @@ _SAMPLE_DASHBOARD_JSON = {
 
 # Sample Dashboard JSON v1.0 point with trace data.
 _SAMPLE_DASHBOARD_JSON_WITH_TRACE = {
-    'master': 'ChromiumPerf',
+    'main': 'ChromiumPerf',
     'bot': 'win7',
     'point_id': '12345',
     'supplemental': {
@@ -147,7 +147,7 @@ class AddPointTest(testing_common.TestCase):
         id='my_sheriff1', email='a@chromium.org', patterns=['*/*/*/dom']).put()
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'dromaeo/dom',
             'revision': 12345,
@@ -160,7 +160,7 @@ class AddPointTest(testing_common.TestCase):
             },
         },
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'dromaeo/jslib',
             'revision': 12345,
@@ -232,17 +232,17 @@ class AddPointTest(testing_common.TestCase):
     self.assertTrue(tests[2].internal_only)
     self.assertIsNone(tests[2].units)
 
-    # Both sample entries have the same master' and 'bot' values, so one
-    # Master and one Bot entity were created.
+    # Both sample entries have the same main' and 'bot' values, so one
+    # Main and one Bot entity were created.
     bots = graph_data.Bot.query().fetch(limit=_FETCH_LIMIT)
     self.assertEqual(1, len(bots))
     self.assertEqual('win7', bots[0].key.id())
     self.assertEqual('ChromiumPerf', bots[0].key.parent().id())
     self.assertTrue(bots[0].internal_only)
-    masters = graph_data.Master.query().fetch(limit=_FETCH_LIMIT)
-    self.assertEqual(1, len(masters))
-    self.assertEqual('ChromiumPerf', masters[0].key.id())
-    self.assertIsNone(masters[0].key.parent())
+    mains = graph_data.Main.query().fetch(limit=_FETCH_LIMIT)
+    self.assertEqual(1, len(mains))
+    self.assertEqual('ChromiumPerf', mains[0].key.id())
+    self.assertIsNone(mains[0].key.parent())
 
     # Verify that an anomaly processing was called.
     mock_process_test.assert_called_once_with(tests[1].key)
@@ -347,7 +347,7 @@ class AddPointTest(testing_common.TestCase):
         extra_environ={'REMOTE_ADDR': _WHITELISTED_IP})
 
   @mock.patch('logging.error')
-  @mock.patch.object(graph_data.Master, 'get_by_id')
+  @mock.patch.object(graph_data.Main, 'get_by_id')
   def testPost_BadRequestError_ErrorLogged(
       self, mock_get_by_id, mock_logging_error):
     """Tests that error is logged if a datastore BadRequestError happens."""
@@ -362,7 +362,7 @@ class AddPointTest(testing_common.TestCase):
     """Tests that an error is returned when the given columns are invalid."""
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'foo/bar/baz',
         }
@@ -375,7 +375,7 @@ class AddPointTest(testing_common.TestCase):
     """Asserts post fails when both revision and version numbers are missing."""
     data_param = json.dumps([
         {
-            'master': 'CrosPerf',
+            'main': 'CrosPerf',
             'bot': 'lumpy',
             'test': 'mach_ports/mach_ports/',
             'value': '231.666666667',
@@ -413,28 +413,28 @@ class AddPointTest(testing_common.TestCase):
   def testPost_UnWhitelistedBots_MarkedInternalOnly(self):
     bot_whitelist.BotWhitelist(
         id=bot_whitelist.WHITELIST_KEY, bots=['linux-release', 'win7']).put()
-    parent = graph_data.Master(id='ChromiumPerf').put()
+    parent = graph_data.Main(id='ChromiumPerf').put()
     parent = graph_data.Bot(
         id='suddenly_secret', parent=parent, internal_only=False).put()
     graph_data.Test(id='dromaeo', parent=parent, internal_only=False).put()
 
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'dromaeo/dom',
             'value': '33.2',
             'revision': '1234',
         },
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'very_secret',
             'test': 'dromaeo/dom',
             'value': '100.1',
             'revision': '1234',
         },
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'suddenly_secret',
             'test': 'dromaeo/dom',
             'value': '22.3',
@@ -493,21 +493,21 @@ class AddPointTest(testing_common.TestCase):
 
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'scrolling_benchmark/mean_frame_time',
             'revision': 123456,
             'value': 700,
         },
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'dromaeo/jslib',
             'revision': 123445,
             'value': 200,
         },
         {
-            'master': 'ChromiumWebkit',
+            'main': 'ChromiumWebkit',
             'bot': 'win7',
             'test': 'dromaeo/jslib',
             'revision': 12345,
@@ -521,23 +521,23 @@ class AddPointTest(testing_common.TestCase):
     self.ExecuteTaskQueueTasks('/add_point_queue', add_point._TASK_QUEUE_NAME)
 
     sheriff1_test = ndb.Key(
-        'Master', 'ChromiumPerf', 'Bot', 'win7',
+        'Main', 'ChromiumPerf', 'Bot', 'win7',
         'Test', 'dromaeo', 'Test', 'jslib').get()
     self.assertEqual(sheriff1, sheriff1_test.sheriff)
 
     sheriff2_test = ndb.Key(
-        'Master', 'ChromiumPerf', 'Bot', 'win7',
+        'Main', 'ChromiumPerf', 'Bot', 'win7',
         'Test', 'scrolling_benchmark',
         'Test', 'mean_frame_time').get()
     self.assertEqual(sheriff2, sheriff2_test.sheriff)
 
     no_sheriff_test = ndb.Key(
-        'Master', 'ChromiumWebkit', 'Bot', 'win7',
+        'Main', 'ChromiumWebkit', 'Bot', 'win7',
         'Test', 'dromaeo', 'Test', 'jslib').get()
     self.assertIsNone(no_sheriff_test.sheriff)
 
     test_suite = ndb.Key(
-        'Master', 'ChromiumPerf', 'Bot', 'win7',
+        'Main', 'ChromiumPerf', 'Bot', 'win7',
         'Test', 'scrolling_benchmark').get()
     self.assertEqual(1, len(test_suite.monitored))
     self.assertEqual('mean_frame_time', test_suite.monitored[0].string_id())
@@ -557,21 +557,21 @@ class AddPointTest(testing_common.TestCase):
 
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'scrolling_benchmark/mean_frame_time',
             'revision': 123456,
             'value': 700,
         },
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'dromaeo/jslib',
             'revision': 123445,
             'value': 200,
         },
         {
-            'master': 'ChromiumWebkit',
+            'main': 'ChromiumWebkit',
             'bot': 'win7',
             'test': 'dromaeo/jslib',
             'revision': 12345,
@@ -585,19 +585,19 @@ class AddPointTest(testing_common.TestCase):
     self.ExecuteTaskQueueTasks('/add_point_queue', add_point._TASK_QUEUE_NAME)
 
     anomaly_config1_test = ndb.Key(
-        'Master', 'ChromiumPerf', 'Bot', 'win7',
+        'Main', 'ChromiumPerf', 'Bot', 'win7',
         'Test', 'dromaeo', 'Test', 'jslib').get()
     self.assertEqual(
         anomaly_config1, anomaly_config1_test.overridden_anomaly_config)
 
     anomaly_config2_test = ndb.Key(
-        'Master', 'ChromiumPerf', 'Bot', 'win7', 'Test',
+        'Main', 'ChromiumPerf', 'Bot', 'win7', 'Test',
         'scrolling_benchmark', 'Test', 'mean_frame_time').get()
     self.assertEqual(
         anomaly_config2, anomaly_config2_test.overridden_anomaly_config)
 
     no_config_test = ndb.Key(
-        'Master', 'ChromiumWebkit', 'Bot', 'win7',
+        'Main', 'ChromiumWebkit', 'Bot', 'win7',
         'Test', 'dromaeo', 'Test', 'jslib').get()
     self.assertIsNone(no_config_test.overridden_anomaly_config)
 
@@ -605,7 +605,7 @@ class AddPointTest(testing_common.TestCase):
     """Tests that units and improvement direction are added for new Tests."""
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'scrolling_benchmark/mean_frame_time',
             'revision': 123456,
@@ -629,7 +629,7 @@ class AddPointTest(testing_common.TestCase):
     self.assertEqual(anomaly.DOWN, tests[1].improvement_direction)
 
   def testPost_NewPointWithNewUnits_TestUnitsAreUpdated(self):
-    parent = graph_data.Master(id='ChromiumPerf').put()
+    parent = graph_data.Main(id='ChromiumPerf').put()
     parent = graph_data.Bot(id='win7', parent=parent).put()
     parent = graph_data.Test(id='scrolling_benchmark', parent=parent).put()
     graph_data.Test(
@@ -638,7 +638,7 @@ class AddPointTest(testing_common.TestCase):
 
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'scrolling_benchmark/mean_frame_time',
             'revision': 123456,
@@ -663,7 +663,7 @@ class AddPointTest(testing_common.TestCase):
 
   def testPost_NewPoint_UpdatesImprovementDirection(self):
     """Tests that adding a point updates units for an existing Test."""
-    parent = graph_data.Master(id='ChromiumPerf').put()
+    parent = graph_data.Main(id='ChromiumPerf').put()
     parent = graph_data.Bot(id='win7', parent=parent).put()
     parent = graph_data.Test(id='scrolling_benchmark', parent=parent).put()
     frame_time_key = graph_data.Test(
@@ -674,7 +674,7 @@ class AddPointTest(testing_common.TestCase):
     self.assertEqual(anomaly.DOWN, test.improvement_direction)
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'scrolling_benchmark/frame_time',
             'revision': 123456,
@@ -697,7 +697,7 @@ class AddPointTest(testing_common.TestCase):
 
   def testPost_DirectionUpdatesWithUnitMap(self):
     """Tests that adding a point updates units for an existing Test."""
-    parent = graph_data.Master(id='ChromiumPerf').put()
+    parent = graph_data.Main(id='ChromiumPerf').put()
     parent = graph_data.Bot(id='win7', parent=parent).put()
     parent = graph_data.Test(id='scrolling_benchmark', parent=parent).put()
     graph_data.Test(
@@ -706,7 +706,7 @@ class AddPointTest(testing_common.TestCase):
         units='ms',
         improvement_direction=anomaly.UNKNOWN).put()
     point = {
-        'master': 'ChromiumPerf',
+        'main': 'ChromiumPerf',
         'bot': 'win7',
         'test': 'scrolling_benchmark/mean_frame_time',
         'revision': 123456,
@@ -728,14 +728,14 @@ class AddPointTest(testing_common.TestCase):
 
   def testPost_AddNewPointToDeprecatedTest_ResetsDeprecated(self):
     """Tests that adding a point sets the test to be non-deprecated."""
-    parent = graph_data.Master(id='ChromiumPerf').put()
+    parent = graph_data.Main(id='ChromiumPerf').put()
     parent = graph_data.Bot(id='win7', parent=parent).put()
     suite = graph_data.Test(
         id='scrolling_benchmark', parent=parent, deprecated=True).put()
     graph_data.Test(id='mean_frame_time', parent=suite, deprecated=True).put()
 
     point = {
-        'master': 'ChromiumPerf',
+        'main': 'ChromiumPerf',
         'bot': 'win7',
         'test': 'scrolling_benchmark/mean_frame_time',
         'revision': 123456,
@@ -790,7 +790,7 @@ class AddPointTest(testing_common.TestCase):
         {'foo': 'bar'})
     data_param = json.dumps([
         {
-            'master': 'ChromiumPerf',
+            'main': 'ChromiumPerf',
             'bot': 'win7',
             'test': 'scrolling_benchmark/mean_frame_time',
             'revision': 123456,
@@ -1021,7 +1021,7 @@ class AddPointTest(testing_common.TestCase):
     self.assertEqual('mavericks', rows[0].a_os)
     self.assertEqual('intel', rows[0].a_gpu_oem)
     test_suite = ndb.Key(
-        'Master', 'ChromiumPerf', 'Bot', 'win7', 'Test', 'my_test_suite').get()
+        'Main', 'ChromiumPerf', 'Bot', 'win7', 'Test', 'my_test_suite').get()
     self.assertEqual('foo', test_suite.description)
 
   def testPost_WithBenchmarkRerunOptions_AddsTraceRerunOptions(self):
@@ -1055,10 +1055,10 @@ class AddPointTest(testing_common.TestCase):
     self.assertEqual('https://console.developer.google.com/m',
                      rows[1].a_tracing_uri)
 
-  def testPost_FormatV1_BadMaster_Rejected(self):
-    """Tests that attempting to post with no master name will error."""
+  def testPost_FormatV1_BadMain_Rejected(self):
+    """Tests that attempting to post with no main name will error."""
     chart = _SAMPLE_DASHBOARD_JSON.copy()
-    del chart['master']
+    del chart['main']
     self.testapp.post(
         '/add_point', {'data': json.dumps(chart)}, status=400,
         extra_environ={'REMOTE_ADDR': _WHITELISTED_IP})

--- a/src/third_party/catapult/dashboard/dashboard/alerts.py
+++ b/src/third_party/catapult/dashboard/dashboard/alerts.py
@@ -171,7 +171,7 @@ def _AlertDict(alert_entity):
       'start_revision': alert_entity.start_revision,
       'end_revision': alert_entity.end_revision,
       'date': str(alert_entity.timestamp.date()),
-      'master': test_path_parts[0],
+      'main': test_path_parts[0],
       'bot': test_path_parts[1],
       'testsuite': test_path_parts[2],
       'test': '/'.join(test_path_parts[3:]),

--- a/src/third_party/catapult/dashboard/dashboard/alerts_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/alerts_test.py
@@ -105,7 +105,7 @@ class AlertsTest(testing_common.TestCase):
       self.assertEqual(expected_end_rev, alert['end_revision'])
       self.assertEqual(expected_end_rev - 5, alert['start_revision'])
       self.assertEqual(key_map[expected_end_rev], alert['key'])
-      self.assertEqual('ChromiumGPU', alert['master'])
+      self.assertEqual('ChromiumGPU', alert['main'])
       self.assertEqual('linux-release', alert['bot'])
       self.assertEqual('scrolling-benchmark', alert['testsuite'])
       if expected_end_rev % 20 == 0:

--- a/src/third_party/catapult/dashboard/dashboard/auto_bisect.py
+++ b/src/third_party/catapult/dashboard/dashboard/auto_bisect.py
@@ -171,7 +171,7 @@ def _MakeBisectTryJob(bug_id, run_count=0):
 
   metric = start_try_job.GuessMetric(test.test_path)
 
-  bisect_bot = start_try_job.GuessBisectBot(test.master_name, test.bot_name)
+  bisect_bot = start_try_job.GuessBisectBot(test.main_name, test.bot_name)
   if not bisect_bot or '_' not in bisect_bot:
     raise NotBisectableError('Could not select a bisect bot.')
 
@@ -179,7 +179,7 @@ def _MakeBisectTryJob(bug_id, run_count=0):
 
   new_bisect_config = start_try_job.GetBisectConfig(
       bisect_bot=bisect_bot,
-      master_name=test.master_name,
+      main_name=test.main_name,
       suite=test.suite_name,
       metric=metric,
       good_revision=good_revision,
@@ -199,7 +199,7 @@ def _MakeBisectTryJob(bug_id, run_count=0):
       bot=bisect_bot,
       config=config_python_string,
       bug_id=bug_id,
-      master_name=test.master_name,
+      main_name=test.main_name,
       internal_only=test.internal_only,
       job_type='bisect',
       use_buildbucket=use_recipe)

--- a/src/third_party/catapult/dashboard/dashboard/bench_find_anomalies.py
+++ b/src/third_party/catapult/dashboard/dashboard/bench_find_anomalies.py
@@ -311,8 +311,8 @@ def _ExtraAlertLinks(bench, change_points_as_lists):
 def _GraphLink(test_key, rev):
   """Returns an HTML link to view the graph for an alert."""
   test_path = utils.TestPath(test_key)
-  master, bot, test = test_path.split('/', 2)
-  query = '?masters=%s&bots=%s&tests=%s&rev=%s' % (master, bot, test, rev)
+  main, bot, test = test_path.split('/', 2)
+  query = '?mains=%s&bots=%s&tests=%s&rev=%s' % (main, bot, test, rev)
   return '<a href="https://%s/report%s">%s/%s@%s</a>' % (
       app_identity.get_default_version_hostname(), query, bot, test, rev)
 

--- a/src/third_party/catapult/dashboard/dashboard/bisect_fyi.py
+++ b/src/third_party/catapult/dashboard/dashboard/bisect_fyi.py
@@ -102,7 +102,7 @@ def _MakeBisectFYITryJob(test_name, bisect_config):
       bot=bisect_bot,
       config=config_python_string,
       bug_id=bisect_config.get('bug_id', -1),
-      master_name='ChromiumPerf',
+      main_name='ChromiumPerf',
       internal_only=True,
       job_type='bisect-fyi',
       use_buildbucket=use_recipe,

--- a/src/third_party/catapult/dashboard/dashboard/buildbucket_job_status_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/buildbucket_job_status_test.py
@@ -20,7 +20,7 @@ SAMPLE_RESPONSE = r"""{
   "created_ts": "1430771172999340",
   "url": "http://build.chromium.org/p/tryserver.chromium.perf/builders\
 /linux_perf_bisector/builds/32",
-  "bucket": "master.tryserver.chromium.perf",
+  "bucket": "main.tryserver.chromium.perf",
   "result_details_json": "{\"properties\": {\
 \"got_nacl_revision\": \"660eb1e1c91349b53f0d60bbf9a92e31f4cf4e1d\", \
 \"got_swarming_client_revision\": \
@@ -28,21 +28,21 @@ SAMPLE_RESPONSE = r"""{
 \"got_revision\": \"d558f46c34085abfc9f59824fdc3466f45c40152\", \
 \"build_url\": \"gs://chrome-perf/Linux Bisector\", \
 \"recipe\": \"bisect\", \
-\"got_webrtc_revision_cp\": \"refs/heads/master@{#9128}\", \
+\"got_webrtc_revision_cp\": \"refs/heads/main@{#9128}\", \
 \"got_webkit_revision_git\": \"44bf01091874592828070dc26cbb5189da9b959b\", \
 \"append_deps_patch_sha\": true, \
 \"project\": \"\", \
 \"got_webkit_revision\": 194864, \
-\"slavename\": \"build74-m4\", \
-\"got_revision_cp\": \"refs/heads/master@{#328178}\", \
+\"subordinatename\": \"build74-m4\", \
+\"got_revision_cp\": \"refs/heads/main@{#328178}\", \
 \"blamelist\": [], \
 \"branch\": \"\", \
 \"revision\": \"\", \
-\"workdir\": \"/b/build/slave/linux_perf_bisector\", \
+\"workdir\": \"/b/build/subordinate/linux_perf_bisector\", \
 \"repository\": \"\", \
 \"buildername\": \"linux_perf_bisector\", \
 \"got_webrtc_revision\": \"0d778c6af22767e9bcc92a278da08b5f82885977\", \
-\"mastername\": \"tryserver.chromium.perf\", \
+\"mainname\": \"tryserver.chromium.perf\", \
 \"got_v8_revision\": \"a06f1b4e013812cc7ad1d52a0ea49206cafa7b67\", \
 \"got_v8_revision_cp\": \"refs/heads/4.4.50@{#1}\", \
 \"buildbotURL\": \"http://build.chromium.org/p/tryserver.chromium.perf/\", \
@@ -58,7 +58,7 @@ rasterize_and_record_micro.key_mobile_sites_smooth\", \
 \"test_type\": \"perf\", \
 \"gs_bucket\": \"chrome-perf\", \
 \"bad_revision\": \"328115\"}, \
-\"got_webkit_revision_cp\": \"refs/heads/master@{#194864}\", \
+\"got_webkit_revision_cp\": \"refs/heads/main@{#194864}\", \
 \"buildnumber\": 32, \
 \"requestedAt\": 1430771180}}",
   "status_changed_ts": "1430771433288620",

--- a/src/third_party/catapult/dashboard/dashboard/buildbucket_service.py
+++ b/src/third_party/catapult/dashboard/dashboard/buildbucket_service.py
@@ -17,7 +17,7 @@ _DISCOVERY_URL = (
     '/_ah/api/discovery/v1/apis/{api}/{apiVersion}/rest')
 
 # Default Buildbucket bucket name.
-_BUCKET_NAME = 'master.tryserver.chromium.perf'
+_BUCKET_NAME = 'main.tryserver.chromium.perf'
 
 # Scope required by the Build Bucket Service.
 _OAUTH2_SCOPE = 'https://www.googleapis.com/auth/userinfo.email'

--- a/src/third_party/catapult/dashboard/dashboard/buildbucket_service_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/buildbucket_service_test.py
@@ -68,7 +68,7 @@ class BuildbucketServiceTest(testing_common.TestCase):
 
     # Ensure the request was composed
     request = self.fake_service.bodies[0]
-    self.assertEqual('master.tryserver.chromium.perf', request['bucket'])
+    self.assertEqual('main.tryserver.chromium.perf', request['bucket'])
     parameters_json = request['parameters_json']
     parameters = json.loads(parameters_json)
     self.assertIsInstance(parameters, dict)

--- a/src/third_party/catapult/dashboard/dashboard/change_internal_only.py
+++ b/src/third_party/catapult/dashboard/dashboard/change_internal_only.py
@@ -30,20 +30,20 @@ class ChangeInternalOnlyHandler(request_handler.RequestHandler):
 
   def get(self):
     """Renders the UI for selecting bots."""
-    masters = {}
+    mains = {}
     bots = graph_data.Bot.query().fetch()
     for bot in bots:
-      master_name = bot.key.parent().string_id()
+      main_name = bot.key.parent().string_id()
       bot_name = bot.key.string_id()
-      bots = masters.setdefault(master_name, [])
+      bots = mains.setdefault(main_name, [])
       bots.append({
           'name': bot_name,
           'internal_only': bot.internal_only,
       })
-    logging.info('MASTERS: %s', masters)
+    logging.info('MASTERS: %s', mains)
 
     self.RenderHtml('change_internal_only.html', {
-        'masters': masters,
+        'mains': mains,
     })
 
   def post(self):
@@ -56,7 +56,7 @@ class ChangeInternalOnlyHandler(request_handler.RequestHandler):
     Request parameters:
       internal_only: "true" if turning on internal_only, else "false".
       bots: Bots to update. Multiple bots parameters are possible; the value
-          of each should be a string like "MasterName/platform-name".
+          of each should be a string like "MainName/platform-name".
       test: An urlsafe Key for a Test entity.
       cursor: An urlsafe Cursor; this parameter is only given if we're part-way
           through processing a Bot or a Test.
@@ -107,8 +107,8 @@ class ChangeInternalOnlyHandler(request_handler.RequestHandler):
 
   def _UpdateBot(self, bot_name, internal_only, cursor=None):
     """Start updating internal_only for the given bot and associated data."""
-    master, bot = bot_name.split('/')
-    bot_key = ndb.Key('Master', master, 'Bot', bot)
+    main, bot = bot_name.split('/')
+    bot_key = ndb.Key('Main', main, 'Bot', bot)
 
     if not cursor:
       # First time updating for this Bot.

--- a/src/third_party/catapult/dashboard/dashboard/debug_alert.py
+++ b/src/third_party/catapult/dashboard/dashboard/debug_alert.py
@@ -31,7 +31,7 @@ class DebugAlertHandler(request_handler.RequestHandler):
     """Displays UI for debugging the anomaly detection function.
 
     Request parameters:
-      test_path: Full test path (Master/bot/suite/chart) for test with alert.
+      test_path: Full test path (Main/bot/suite/chart) for test with alert.
       rev: A revision (Row id number) to center the graph on.
       num_before: Maximum number of points after the given revision to get.
       num_after: Maximum number of points before the given revision.
@@ -326,7 +326,7 @@ def _CsvUrl(test_path, rows):
 def _GraphUrl(test, revision):
   """Constructs an URL for requesting data from /graph_csv for |rows|."""
   params = [
-      ('masters', test.master_name),
+      ('mains', test.main_name),
       ('bots', test.bot_name),
       ('tests', '/'.join(test.test_path.split('/')[2:])),
   ]

--- a/src/third_party/catapult/dashboard/dashboard/debug_alert_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/debug_alert_test.py
@@ -191,20 +191,20 @@ class DebugAlertTest(testing_common.TestCase):
     test_key = self._AddSampleData()
     # Both string and int can be accepted for revision.
     self.assertEqual(
-        '/report?masters=M&bots=b&tests=suite%2Ffoo&rev=310',
+        '/report?mains=M&bots=b&tests=suite%2Ffoo&rev=310',
         debug_alert._GraphUrl(test_key.get(), 310))
     self.assertEqual(
-        '/report?masters=M&bots=b&tests=suite%2Ffoo&rev=310',
+        '/report?mains=M&bots=b&tests=suite%2Ffoo&rev=310',
         debug_alert._GraphUrl(test_key.get(), '310'))
 
   def testGraphUrl_NoRevisionGiven_NoRevisionParamInUrl(self):
     test_key = self._AddSampleData()
     # Both None and empty string mean "no revision".
     self.assertEqual(
-        '/report?masters=M&bots=b&tests=suite%2Ffoo',
+        '/report?mains=M&bots=b&tests=suite%2Ffoo',
         debug_alert._GraphUrl(test_key.get(), ''))
     self.assertEqual(
-        '/report?masters=M&bots=b&tests=suite%2Ffoo',
+        '/report?mains=M&bots=b&tests=suite%2Ffoo',
         debug_alert._GraphUrl(test_key.get(), None))
 
 

--- a/src/third_party/catapult/dashboard/dashboard/dump_graph_json.py
+++ b/src/third_party/catapult/dashboard/dashboard/dump_graph_json.py
@@ -41,13 +41,13 @@ class DumpGraphJsonHandler(request_handler.RequestHandler):
     """Dumps data for the requested test.
 
     Request parameters:
-      test_path: A single full test path, including master/bot.
+      test_path: A single full test path, including main/bot.
       num_points: Max number of Row entities (optional).
       end_rev: Ending revision number, inclusive (optional).
 
     Outputs:
       JSON array of encoded protobuf messages, which encode all of
-      the datastore entities relating to one test (including Master, Bot,
+      the datastore entities relating to one test (including Main, Bot,
       Test, Row, Anomaly and Sheriff entities).
     """
     test_path = self.request.get('test_path')
@@ -90,7 +90,7 @@ class DumpGraphJsonHandler(request_handler.RequestHandler):
 
     Outputs:
       JSON array of encoded protobuf messages, which encode all of
-      the datastore entities relating to one test (including Master, Bot,
+      the datastore entities relating to one test (including Main, Bot,
       Test, Row, Anomaly and Sheriff entities).
     """
     sheriff_name = self.request.get('sheriff')
@@ -121,7 +121,7 @@ class DumpGraphJsonHandler(request_handler.RequestHandler):
     self.response.out.write(json.dumps(protobuf_strings))
 
   def _GetTestAncestors(self, test_keys):
-    """Get the Test, Bot, and Master entities that are ancestors of test."""
+    """Get the Test, Bot, and Main entities that are ancestors of test."""
     entities = []
     added_parents = set()
     for test_key in test_keys:

--- a/src/third_party/catapult/dashboard/dashboard/dump_graph_json_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/dump_graph_json_test.py
@@ -31,15 +31,15 @@ class DumpGraphJsonTest(testing_common.TestCase):
     testing_common.AddTests('M', 'b', {'foo': {}})
 
     # When a request is made for this one test, three entities should
-    # be returned: the Master, Bot and Test entities.
+    # be returned: the Main, Bot and Test entities.
     response = self.testapp.get('/dump_graph_json', {'test_path': 'M/b/foo'})
     protobuf_strings = json.loads(response.body)
     entities = map(dump_graph_json.BinaryProtobufToEntity, protobuf_strings)
     self.assertEqual(3, len(entities))
-    masters = _EntitiesOfKind(entities, 'Master')
+    mains = _EntitiesOfKind(entities, 'Main')
     bots = _EntitiesOfKind(entities, 'Bot')
     tests = _EntitiesOfKind(entities, 'Test')
-    self.assertEqual('M', masters[0].key.string_id())
+    self.assertEqual('M', mains[0].key.string_id())
     self.assertEqual('b', bots[0].key.string_id())
     self.assertEqual('foo', tests[0].key.string_id())
 

--- a/src/third_party/catapult/dashboard/dashboard/edit_anomaly_configs_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/edit_anomaly_configs_test.py
@@ -62,13 +62,13 @@ class EditAnomalyConfigsTest(testing_common.TestCase):
     self.SetCurrentUser('sullivan@chromium.org', is_admin=True)
     anomaly_config.AnomalyConfig(
         id='Existing Config', config={'old': 11},
-        patterns=['MyMaster/*/*/*']).put()
+        patterns=['MyMain/*/*/*']).put()
 
     self.testapp.post('/edit_anomaly_configs', {
         'add-edit': 'edit',
         'edit-name': 'Existing Config',
         'config': '{"new": 10}',
-        'patterns': 'MyMaster/*/*/*',
+        'patterns': 'MyMain/*/*/*',
         'xsrf_token': xsrf.GenerateToken(users.get_current_user()),
     })
 
@@ -76,13 +76,13 @@ class EditAnomalyConfigsTest(testing_common.TestCase):
     self.assertEqual(len(anomaly_configs), 1)
     self.assertEqual('Existing Config', anomaly_configs[0].key.string_id())
     self.assertEqual({'new': 10}, anomaly_configs[0].config)
-    self.assertEqual(['MyMaster/*/*/*'], anomaly_configs[0].patterns)
+    self.assertEqual(['MyMain/*/*/*'], anomaly_configs[0].patterns)
 
   def testEdit_AddPattern(self):
     """Tests changing the patterns list of an existing AnomalyConfig."""
     self.SetCurrentUser('sullivan@chromium.org', is_admin=True)
-    master = graph_data.Master(id='TheMaster').put()
-    bot = graph_data.Bot(id='TheBot', parent=master).put()
+    main = graph_data.Main(id='TheMain').put()
+    bot = graph_data.Bot(id='TheBot', parent=main).put()
     suite1 = graph_data.Test(id='Suite1', parent=bot).put()
     suite2 = graph_data.Test(id='Suite2', parent=bot).put()
     test_aaa = graph_data.Test(id='aaa', parent=suite1, has_rows=True).put()
@@ -144,8 +144,8 @@ class EditAnomalyConfigsTest(testing_common.TestCase):
     anomaly_config_key = anomaly_config.AnomalyConfig(
         id='Test Config', config={'a': 10},
         patterns=['*/*/one', '*/*/two']).put()
-    master = graph_data.Master(id='TheMaster').put()
-    bot = graph_data.Bot(id='TheBot', parent=master).put()
+    main = graph_data.Main(id='TheMain').put()
+    bot = graph_data.Bot(id='TheBot', parent=main).put()
     test_one = graph_data.Test(
         id='one', parent=bot, overridden_anomaly_config=anomaly_config_key,
         has_rows=True).put()
@@ -156,7 +156,7 @@ class EditAnomalyConfigsTest(testing_common.TestCase):
     # Verify the state of the data before making the request.
     self.assertEqual(['*/*/one', '*/*/two'], anomaly_config_key.get().patterns)
     self.assertEqual(
-        ['TheMaster/TheBot/one'],
+        ['TheMain/TheBot/one'],
         list_tests.GetTestsMatchingPattern('*/*/one'))
 
     self.testapp.post('/edit_anomaly_configs', {

--- a/src/third_party/catapult/dashboard/dashboard/edit_config_handler_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/edit_config_handler_test.py
@@ -28,8 +28,8 @@ class EditConfigHandlerTest(testing_common.TestCase):
 
   def _AddSampleTestData(self):
     """Adds some sample data used in the tests below."""
-    master = graph_data.Master(id='TheMaster').put()
-    bot = graph_data.Bot(id='TheBot', parent=master).put()
+    main = graph_data.Main(id='TheMain').put()
+    bot = graph_data.Bot(id='TheBot', parent=main).put()
     suite1 = graph_data.Test(id='Suite1', parent=bot).put()
     suite2 = graph_data.Test(id='Suite2', parent=bot).put()
     graph_data.Test(id='aaa', parent=suite1, has_rows=True).put()
@@ -57,7 +57,7 @@ class EditConfigHandlerTest(testing_common.TestCase):
         edit_config_handler._SplitPatternLines('A/b/c/d\n\nE/f/g/h\n'))
 
   def testSplitPatternLines_NoSlashes_RaisesError(self):
-    # A valid test path must contain a master, bot, and test part.
+    # A valid test path must contain a main, bot, and test part.
     with self.assertRaises(request_handler.InvalidInputError):
       edit_config_handler._SplitPatternLines('invalid')
 
@@ -81,25 +81,25 @@ class EditConfigHandlerTest(testing_common.TestCase):
   def testChangeTestPatterns_OnlyAdd_ReturnsAddedAndEmptySet(self):
     self._AddSampleTestData()
     self.assertEqual(
-        ({'TheMaster/TheBot/Suite1/aaa'}, set()),
+        ({'TheMain/TheBot/Suite1/aaa'}, set()),
         edit_config_handler._ChangeTestPatterns(
             ['*/*/*/bbb'], ['*/*/*/aaa', '*/*/*/bbb']))
 
   def testChangeTestPatterns_OnlyRemove_ReturnsEmptySetAndRemoved(self):
     self._AddSampleTestData()
     self.assertEqual(
-        (set(), {'TheMaster/TheBot/Suite1/bbb'}),
+        (set(), {'TheMain/TheBot/Suite1/bbb'}),
         edit_config_handler._ChangeTestPatterns(
             ['*/*/*/aaa', '*/*/Suite1/bbb'], ['*/*/*/aaa']))
 
   def testChangeTestPatterns_RemoveAndAdd_ReturnsAddedAndRemoved(self):
     self._AddSampleTestData()
     added = {
-        'TheMaster/TheBot/Suite1/aaa',
+        'TheMain/TheBot/Suite1/aaa',
     }
     removed = {
-        'TheMaster/TheBot/Suite2/ccc',
-        'TheMaster/TheBot/Suite2/ddd',
+        'TheMain/TheBot/Suite2/ccc',
+        'TheMain/TheBot/Suite2/ddd',
     }
     self.assertEqual(
         (added, removed),
@@ -109,7 +109,7 @@ class EditConfigHandlerTest(testing_common.TestCase):
   def testChangeTestPatterns_CanTakeSetsAsArguments(self):
     self._AddSampleTestData()
     self.assertEqual(
-        ({'TheMaster/TheBot/Suite1/aaa'}, set()),
+        ({'TheMain/TheBot/Suite1/aaa'}, set()),
         edit_config_handler._ChangeTestPatterns(set(), {'*/*/Suite1/aaa'}))
 
   def testComputeDeltas_Empty(self):

--- a/src/third_party/catapult/dashboard/dashboard/edit_sheriffs_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/edit_sheriffs_test.py
@@ -33,8 +33,8 @@ class EditSheriffsTest(testing_common.TestCase):
 
   def _AddSampleTestData(self):
     """Adds some sample data used in the tests below."""
-    master = graph_data.Master(id='TheMaster').put()
-    bot = graph_data.Bot(id='TheBot', parent=master).put()
+    main = graph_data.Main(id='TheMain').put()
+    bot = graph_data.Bot(id='TheBot', parent=main).put()
     suite1 = graph_data.Test(id='Suite1', parent=bot).put()
     suite2 = graph_data.Test(id='Suite2', parent=bot).put()
     graph_data.Test(id='aaa', parent=suite1, has_rows=True).put()
@@ -90,10 +90,10 @@ class EditSheriffsTest(testing_common.TestCase):
     # After the tasks get executed, the Test entities should also be updated.
     self.ExecuteTaskQueueTasks(
         '/put_entities_task', edit_config_handler._TASK_QUEUE_NAME)
-    aaa = utils.TestKey('TheMaster/TheBot/Suite1/aaa').get()
-    bbb = utils.TestKey('TheMaster/TheBot/Suite1/bbb').get()
-    ccc = utils.TestKey('TheMaster/TheBot/Suite2/ccc').get()
-    ddd = utils.TestKey('TheMaster/TheBot/Suite2/ddd').get()
+    aaa = utils.TestKey('TheMain/TheBot/Suite1/aaa').get()
+    bbb = utils.TestKey('TheMain/TheBot/Suite1/bbb').get()
+    ccc = utils.TestKey('TheMain/TheBot/Suite2/ccc').get()
+    ddd = utils.TestKey('TheMain/TheBot/Suite2/ddd').get()
     self.assertEqual(sheriff_entity.key, aaa.sheriff)
     self.assertEqual(sheriff_entity.key, bbb.sheriff)
     self.assertIsNone(ccc.sheriff)
@@ -114,10 +114,10 @@ class EditSheriffsTest(testing_common.TestCase):
     # After the tasks get executed, the Test entities should also be updated.
     self.ExecuteTaskQueueTasks(
         '/put_entities_task', edit_config_handler._TASK_QUEUE_NAME)
-    aaa = utils.TestKey('TheMaster/TheBot/Suite1/aaa').get()
-    bbb = utils.TestKey('TheMaster/TheBot/Suite1/bbb').get()
-    ccc = utils.TestKey('TheMaster/TheBot/Suite2/ccc').get()
-    ddd = utils.TestKey('TheMaster/TheBot/Suite2/ddd').get()
+    aaa = utils.TestKey('TheMain/TheBot/Suite1/aaa').get()
+    bbb = utils.TestKey('TheMain/TheBot/Suite1/bbb').get()
+    ccc = utils.TestKey('TheMain/TheBot/Suite2/ccc').get()
+    ddd = utils.TestKey('TheMain/TheBot/Suite2/ddd').get()
     self.assertIsNone(aaa.sheriff)
     self.assertIsNone(bbb.sheriff)
     self.assertEqual(sheriff_entity.key, ccc.sheriff)

--- a/src/third_party/catapult/dashboard/dashboard/email_template.py
+++ b/src/third_party/catapult/dashboard/dashboard/email_template.py
@@ -20,7 +20,7 @@ _SINGLE_EMAIL_SUBJECT = (
 _EMAIL_HTML_TABLE = """
 A <b>%(percent_changed)s</b> %(change_type)s.<br>
 <table cellpadding='4'>
-  <tr><td>Master:</td><td><b>%(master)s</b></td>
+  <tr><td>Main:</td><td><b>%(main)s</b></td>
   <tr><td>Bot:</td><td><b>%(bot)s</b></td>
   <tr><td>Test:</td><td><b>%(test_name)s</b></td>
   <tr><td>Revision Range:</td><td><b>%(start)d - %(end)d</b></td>
@@ -33,7 +33,7 @@ and <a href='%(bug_url)s'>file a bug</a>.<br>
 _SUMMARY_EMAIL_TEXT_BODY = """
 A %(percent_changed)s %(change_type)s:
 
-Master: %(master)s
+Main: %(main)s
 Bot: %(bot)s
 Test: %(test_name)s
 Revision Range:%(start)d - %(end)d
@@ -229,7 +229,7 @@ def GetReportPageLink(test_path, rev=None, add_protocol_and_host=True):
   path_parts = test_path.split('/')
   if len(path_parts) < 4:
     logging.error('Could not make link, invalid test path: %s', test_path)
-  master, bot = path_parts[0], path_parts[1]
+  main, bot = path_parts[0], path_parts[1]
   test_name = '/'.join(path_parts[2:])
   trace_name = path_parts[-1]
   trace_names = ','.join([trace_name, trace_name + '_ref', 'ref'])
@@ -238,7 +238,7 @@ def GetReportPageLink(test_path, rev=None, add_protocol_and_host=True):
   else:
     link_template = '/report?%s'
   uri = link_template % urllib.urlencode([
-      ('masters', master),
+      ('mains', main),
       ('bots', bot),
       ('tests', test_name),
       ('checked', trace_names),
@@ -274,7 +274,7 @@ def GetAlertInfo(alert, test):
   change_type = 'improvement' if alert.is_improvement else 'regression'
   test_name = '/'.join(test.test_path.split('/')[2:])
   sheriff_name = alert.sheriff.string_id()
-  master = test.master_name
+  main = test.main_name
   bot = test.bot_name
 
   graph_url = GetGroupReportPageLink(alert)
@@ -283,7 +283,7 @@ def GetAlertInfo(alert, test):
   interpolation_parameters = {
       'percent_changed': percent_changed,
       'change_type': change_type,
-      'master': master,
+      'main': main,
       'bot': bot,
       'test_name': test_name,
       'sheriff_name': sheriff_name,

--- a/src/third_party/catapult/dashboard/dashboard/email_template_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/email_template_test.py
@@ -22,7 +22,7 @@ class EmailTemplateTest(unittest.TestCase):
         'ABC/bot-name/abc-perf-test/passed%', '1415919839',
         add_protocol_and_host=False)
 
-    self.assertEquals(('/report?masters=ABC&bots=bot-name&tests='
+    self.assertEquals(('/report?mains=ABC&bots=bot-name&tests='
                        'abc-perf-test%2Fpassed%25&checked=passed%25%2C'
                        'passed%25_ref%2Cref&rev=1415919839'),
                       actual_output_no_host)

--- a/src/third_party/catapult/dashboard/dashboard/embed.py
+++ b/src/third_party/catapult/dashboard/dashboard/embed.py
@@ -15,10 +15,10 @@ class EmbedHandler(chart_handler.ChartHandler):
     """Renders the UI for a simple, embeddable chart.
 
     Request parameters:
-      masters: Comma-separated list of master names.
+      mains: Comma-separated list of main names.
       bots: Comma-separated list of bot names.
       tests: Comma-separated list of of slash-separated test paths
-          (without master/bot).
+          (without main/bot).
       rev: Revision number (optional).
       num_points: Number of points to plot (optional).
       start_rev: Starting evision number (optional).

--- a/src/third_party/catapult/dashboard/dashboard/file_bug_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/file_bug_test.py
@@ -43,7 +43,7 @@ class FileBugTest(testing_common.TestCase):
 
   def _AddSampleAlerts(self):
     """Adds sample data and returns a dict of rev to anomaly key."""
-    # Add sample sheriff, masters, bots, and tests.
+    # Add sample sheriff, mains, bots, and tests.
     sheriff_key = sheriff.Sheriff(id='Sheriff').put()
     testing_common.AddTests(['ChromiumPerf'], ['linux'], {
         'scrolling': {

--- a/src/third_party/catapult/dashboard/dashboard/graph_csv_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/graph_csv_test.py
@@ -25,10 +25,10 @@ class GraphCsvTest(testing_common.TestCase):
     self.SetCurrentUser('foo@bar.com', is_admin=True)
 
   def _AddMockData(self):
-    master = graph_data.Master(id='ChromiumPerf').put()
+    main = graph_data.Main(id='ChromiumPerf').put()
     bots = []
     for name in ['win7', 'mac']:
-      bot = graph_data.Bot(id=name, parent=master).put()
+      bot = graph_data.Bot(id=name, parent=main).put()
       bots.append(bot)
       test = graph_data.Test(id='dromaeo', parent=bot).put()
       dom_test = graph_data.Test(id='dom', parent=test, has_rows=True).put()
@@ -38,10 +38,10 @@ class GraphCsvTest(testing_common.TestCase):
                        error=(i + 5)).put()
 
   def _AddMockInternalData(self):
-    master = graph_data.Master(id='ChromiumPerf').put()
+    main = graph_data.Main(id='ChromiumPerf').put()
     bots = []
     for name in ['win7', 'mac']:
-      bot = graph_data.Bot(id=name, parent=master, internal_only=True).put()
+      bot = graph_data.Bot(id=name, parent=main, internal_only=True).put()
       bots.append(bot)
       test = graph_data.Test(id='dromaeo', parent=bot, internal_only=True).put()
       dom_test = graph_data.Test(id='dom', parent=test, has_rows=True).put()

--- a/src/third_party/catapult/dashboard/dashboard/graph_json.py
+++ b/src/third_party/catapult/dashboard/dashboard/graph_json.py
@@ -212,8 +212,8 @@ def _GetOldStdioUri(row, test):
   Returns:
     An URI string, or None if none can be made.
   """
-  # A masterid and buildname are required to construct a valid URI.
-  if (not hasattr(test, 'masterid') or not hasattr(test, 'buildername')
+  # A mainid and buildname are required to construct a valid URI.
+  if (not hasattr(test, 'mainid') or not hasattr(test, 'buildername')
       or not hasattr(row, 'buildnumber')):
     return None
 
@@ -222,7 +222,7 @@ def _GetOldStdioUri(row, test):
     return None
   return '%s/%s/builders/%s/builds/%s/steps/%s/logs/stdio' % (
       buildbot_uri_prefix,
-      urllib.quote(test.masterid),
+      urllib.quote(test.mainid),
       urllib.quote(test.buildername),
       urllib.quote(str(getattr(row, 'buildnumber'))),
       urllib.quote(test.suite_name))

--- a/src/third_party/catapult/dashboard/dashboard/graph_json_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/graph_json_test.py
@@ -44,12 +44,12 @@ class GraphJsonTest(testing_common.TestCase):
       end_rev: Ending revision number.
       step: Difference between adjacent revisions.
     """
-    master = graph_data.Master(id='ChromiumGPU')
-    master.put()
+    main = graph_data.Main(id='ChromiumGPU')
+    main.put()
     bots = []
     rows = []
     for name in ['winXP', 'win7', 'mac']:
-      bot = graph_data.Bot(id=name, parent=master.key)
+      bot = graph_data.Bot(id=name, parent=main.key)
       bot.put()
       bots.append(bot)
       test = graph_data.Test(id='dromaeo', parent=bot.key)
@@ -80,9 +80,9 @@ class GraphJsonTest(testing_common.TestCase):
       end_rev: Ending revision number.
       step: Difference between adjacent revisions.
     """
-    master = graph_data.Master(id='master')
-    master.put()
-    bot = graph_data.Bot(id='bot', parent=master.key)
+    main = graph_data.Main(id='main')
+    main.put()
+    bot = graph_data.Bot(id='bot', parent=main.key)
     bot.put()
     test = graph_data.Test(id='suite', parent=bot.key)
     test.put()
@@ -175,7 +175,7 @@ class GraphJsonTest(testing_common.TestCase):
     self._AddLongTestColumns(start_rev=15700, end_rev=16000, step=1)
     graphs = {
         'test_path_dict': {
-            'master/bot/suite/sub1/sub2/sub3/sub4/sub5': ['sub5']
+            'main/bot/suite/sub1/sub2/sub3/sub4/sub5': ['sub5']
         },
         'is_selected': True
     }
@@ -189,7 +189,7 @@ class GraphJsonTest(testing_common.TestCase):
     self._AddLongTestColumns(start_rev=15700, end_rev=16000, step=1)
     graphs = {
         'test_path_dict': {
-            'master/bot/suite/sub1/sub2/sub3/sub4': ['sub4']
+            'main/bot/suite/sub1/sub2/sub3/sub4': ['sub4']
         }
     }
     # If the request is valid, a valid response will be returned.
@@ -202,7 +202,7 @@ class GraphJsonTest(testing_common.TestCase):
     self._AddLongTestColumns(start_rev=15700, end_rev=16000, step=1)
     graphs = {
         'test_path_dict': {
-            'master/bot/suite/sub1/sub2/sub3/sub4/sub5': ['sub5']
+            'main/bot/suite/sub1/sub2/sub3/sub4/sub5': ['sub5']
         },
     }
     # If the request is valid, a valid response will be returned.
@@ -280,7 +280,7 @@ class GraphJsonTest(testing_common.TestCase):
 
     rows = graph_data.Row.query(
         graph_data.Row.parent_test == ndb.Key(
-            'Master', 'ChromiumGPU', 'Bot', 'win7',
+            'Main', 'ChromiumGPU', 'Bot', 'win7',
             'Test', 'dromaeo', 'Test', 'dom')).fetch()
     for row in rows:
       row.error = 1 + ((row.revision - 15000) * 0.25)
@@ -616,7 +616,7 @@ class GraphJsonTest(testing_common.TestCase):
   def testGetGraphJson_UnSelectedTrace(self):
     self._AddTestColumns(start_rev=15000, end_rev=15050)
     test_key = ndb.Key(
-        'Master', 'ChromiumGPU', 'Bot', 'win7',
+        'Main', 'ChromiumGPU', 'Bot', 'win7',
         'Test', 'dromaeo', 'Test', 'jslib')
     rows = graph_data.Row.query(graph_data.Row.parent_test == test_key).fetch()
     for row in rows:
@@ -669,9 +669,9 @@ class GraphJsonParseRequestArgumentsTest(testing_common.TestCase):
     """Returns a GraphJsonHandler object with canned request parameters."""
     request_params = {
         'test_path_dict': {
-            'Master/b1/scrolling/frame_times/about.com': [],
-            'Master/b2/scrolling/frame_times/about.com': [],
-            'Master/linux/dromaeo.domcoremodify/dom': [],
+            'Main/b1/scrolling/frame_times/about.com': [],
+            'Main/b2/scrolling/frame_times/about.com': [],
+            'Main/linux/dromaeo.domcoremodify/dom': [],
         }
     }
     request_params.update(params)
@@ -687,9 +687,9 @@ class GraphJsonParseRequestArgumentsTest(testing_common.TestCase):
     handler = self._HandlerWithMockRequestParams(rev='12345', num_points='123')
     expected = {
         'test_path_dict': {
-            'Master/b1/scrolling/frame_times/about.com': [],
-            'Master/b2/scrolling/frame_times/about.com': [],
-            'Master/linux/dromaeo.domcoremodify/dom': [],
+            'Main/b1/scrolling/frame_times/about.com': [],
+            'Main/b2/scrolling/frame_times/about.com': [],
+            'Main/linux/dromaeo.domcoremodify/dom': [],
         },
         'rev': 12345,
         'num_points': 123,
@@ -704,9 +704,9 @@ class GraphJsonParseRequestArgumentsTest(testing_common.TestCase):
     handler = self._HandlerWithMockRequestParams()
     expected = {
         'test_path_dict': {
-            'Master/b1/scrolling/frame_times/about.com': [],
-            'Master/b2/scrolling/frame_times/about.com': [],
-            'Master/linux/dromaeo.domcoremodify/dom': [],
+            'Main/b1/scrolling/frame_times/about.com': [],
+            'Main/b2/scrolling/frame_times/about.com': [],
+            'Main/linux/dromaeo.domcoremodify/dom': [],
         },
         'rev': None,
         'num_points': graph_json._DEFAULT_NUM_POINTS,
@@ -721,9 +721,9 @@ class GraphJsonParseRequestArgumentsTest(testing_common.TestCase):
     handler = self._HandlerWithMockRequestParams(rev='-1')
     expected = {
         'test_path_dict': {
-            'Master/b1/scrolling/frame_times/about.com': [],
-            'Master/b2/scrolling/frame_times/about.com': [],
-            'Master/linux/dromaeo.domcoremodify/dom': [],
+            'Main/b1/scrolling/frame_times/about.com': [],
+            'Main/b2/scrolling/frame_times/about.com': [],
+            'Main/linux/dromaeo.domcoremodify/dom': [],
         },
         'rev': None,
         'num_points': graph_json._DEFAULT_NUM_POINTS,
@@ -736,39 +736,39 @@ class GraphJsonParseRequestArgumentsTest(testing_common.TestCase):
 
 class GraphJsonHelperFunctionTest(testing_common.TestCase):
 
-  def testGetOldStdioUri_NoMasterId_NoURIReturned(self):
-    testing_common.AddTests(['Master'], ['b'], {'my_suite': {}})
-    test = utils.TestKey('Master/b/my_suite').get()
+  def testGetOldStdioUri_NoMainId_NoURIReturned(self):
+    testing_common.AddTests(['Main'], ['b'], {'my_suite': {}})
+    test = utils.TestKey('Main/b/my_suite').get()
     test.buildername = 'MyBuilder'
     row = graph_data.Row(id=345, buildnumber=456)
     self.assertIsNone(graph_json._GetOldStdioUri(row, test))
 
-  def testGetOldStdioUri_WithMasterId_URIReturned(self):
-    testing_common.AddTests(['Master'], ['b'], {'my_suite': {}})
-    test = utils.TestKey('Master/b/my_suite').get()
+  def testGetOldStdioUri_WithMainId_URIReturned(self):
+    testing_common.AddTests(['Main'], ['b'], {'my_suite': {}})
+    test = utils.TestKey('Main/b/my_suite').get()
     test.buildername = 'MyBuilder'
     row = graph_data.Row(id=345, buildnumber=456)
-    test.masterid = 'my.master.id'
+    test.mainid = 'my.main.id'
     self.assertEqual(
         ('http://build.chromium.org/p/my.master.id/builders/MyBuilder'
          '/builds/456/steps/my_suite/logs/stdio'),
         graph_json._GetOldStdioUri(row, test))
 
   def testGetOldStdioUri_InternalOnly_NoURIReturned(self):
-    testing_common.AddTests(['Master'], ['b'], {'my_suite': {}})
-    test = utils.TestKey('Master/b/my_suite').get()
+    testing_common.AddTests(['Main'], ['b'], {'my_suite': {}})
+    test = utils.TestKey('Main/b/my_suite').get()
     test.buildername = 'MyBuilder'
     row = graph_data.Row(id=345, buildnumber=456)
-    test.masterid = 'my.master.id'
+    test.mainid = 'my.main.id'
     test.internal_only = True
     self.assertIsNone(graph_json._GetOldStdioUri(row, test))
 
   def testGetOldStdioUri_CustomPrefix_CustomPrefixUsed(self):
-    testing_common.AddTests(['Master'], ['b'], {'my_suite': {}})
-    test = utils.TestKey('Master/b/my_suite').get()
+    testing_common.AddTests(['Main'], ['b'], {'my_suite': {}})
+    test = utils.TestKey('Main/b/my_suite').get()
     test.buildername = 'MyBuilder'
     row = graph_data.Row(id=345, buildnumber=456)
-    test.masterid = 'my.master.id'
+    test.mainid = 'my.main.id'
     test.internal_only = True
     # If the row has a custom prefix, that will be used, even if the test is
     # internal-only.
@@ -779,8 +779,8 @@ class GraphJsonHelperFunctionTest(testing_common.TestCase):
         graph_json._GetOldStdioUri(row, test))
 
   def testPointInfoDict_StdioUriMarkdown(self):
-    testing_common.AddTests(['Master'], ['b'], {'my_suite': {}})
-    test = utils.TestKey('Master/b/my_suite').get()
+    testing_common.AddTests(['Main'], ['b'], {'my_suite': {}})
+    test = utils.TestKey('Main/b/my_suite').get()
     test.buildername = 'MyBuilder'
     test_container_key = utils.GetTestContainerKey(test)
     row = graph_data.Row(id=345, buildnumber=456, parent=test_container_key)
@@ -791,9 +791,9 @@ class GraphJsonHelperFunctionTest(testing_common.TestCase):
     self.assertEqual(row.a_stdio_uri, point_info['a_stdio_uri'])
 
   def testPointInfoDict_RowHasNoTracingUri_ResultHasNoTracingUri(self):
-    testing_common.AddTests(['Master'], ['b'], {'my_suite': {}})
-    test = utils.TestKey('Master/b/my_suite').get()
-    rows = testing_common.AddRows('Master/b/my_suite', [345])
+    testing_common.AddTests(['Main'], ['b'], {'my_suite': {}})
+    test = utils.TestKey('Main/b/my_suite').get()
+    rows = testing_common.AddRows('Main/b/my_suite', [345])
     # This row has no a_tracing_uri property, so there should be no
     # trace annotation returned by _PointInfoDict.
     point_info = graph_json._PointInfoDict(rows[0], test, {})

--- a/src/third_party/catapult/dashboard/dashboard/graph_revisions.py
+++ b/src/third_party/catapult/dashboard/dashboard/graph_revisions.py
@@ -34,7 +34,7 @@ class GraphRevisionsHandler(request_handler.RequestHandler):
     """Fetches a list of revisions and values for a given test.
 
     Request parameters:
-      test_path: Full test path (including master/bot) for one Test entity.
+      test_path: Full test path (including main/bot) for one Test entity.
 
     Outputs:
       A JSON list of 3-item lists [revision, value, timestamp].

--- a/src/third_party/catapult/dashboard/dashboard/graph_revisions_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/graph_revisions_test.py
@@ -26,9 +26,9 @@ class GraphRevisionsTest(testing_common.TestCase):
 
   def _AddMockData(self):
     """Adds mock data to the datastore, not updating stored_object."""
-    master_key = graph_data.Master(id='ChromiumPerf').put()
+    main_key = graph_data.Main(id='ChromiumPerf').put()
     for bot_name in ['win7', 'mac']:
-      bot_key = graph_data.Bot(id=bot_name, parent=master_key).put()
+      bot_key = graph_data.Bot(id=bot_name, parent=main_key).put()
       test_key = graph_data.Test(id='dromaeo', parent=bot_key).put()
       subtest_key = graph_data.Test(
           id='dom', parent=test_key, has_rows=True).put()

--- a/src/third_party/catapult/dashboard/dashboard/group_report.py
+++ b/src/third_party/catapult/dashboard/dashboard/group_report.py
@@ -190,7 +190,7 @@ def _GetSubTestsForAlerts(alert_list):
   """Gets subtest dict for list of alerts."""
   subtests = {}
   for alert in alert_list:
-    bot_name = alert['master'] + '/' + alert['bot']
+    bot_name = alert['main'] + '/' + alert['bot']
     testsuite = alert['testsuite']
     if bot_name not in subtests:
       subtests[bot_name] = {}
@@ -218,7 +218,7 @@ def _GetOverlaps(anomalies, start, end):
 def _GetOwnerInfo(alert_dicts):
   """Gets a list of owner info for list of alerts for bug with bisect result.
 
-  Test owners are retrieved by a set of master and test suite name from each
+  Test owners are retrieved by a set of main and test suite name from each
   alert in alert_dicts.
 
   Args:
@@ -227,7 +227,7 @@ def _GetOwnerInfo(alert_dicts):
   Returns:
     A list of dictionary containing owner information.
   """
-  test_suite_paths = {'%s/%s' % (a['master'], a['testsuite'])
+  test_suite_paths = {'%s/%s' % (a['main'], a['testsuite'])
                       for a in alert_dicts}
   owners = test_owner.GetOwners(test_suite_paths)
   return [{'email': owner} for owner in owners]

--- a/src/third_party/catapult/dashboard/dashboard/list_monitored_tests_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/list_monitored_tests_test.py
@@ -25,8 +25,8 @@ class ListMonitoredTestsTest(testing_common.TestCase):
 
   def _AddSampleTestData(self):
     """Adds some sample data used in the tests below."""
-    master = graph_data.Master(id='TheMaster').put()
-    bot = graph_data.Bot(id='TheBot', parent=master).put()
+    main = graph_data.Main(id='TheMain').put()
+    bot = graph_data.Bot(id='TheBot', parent=main).put()
     suite1 = graph_data.Test(id='Suite1', parent=bot).put()
     suite2 = graph_data.Test(id='Suite2', parent=bot).put()
     graph_data.Test(id='aaa', parent=suite1, has_rows=True).put()
@@ -47,7 +47,7 @@ class ListMonitoredTestsTest(testing_common.TestCase):
     response = self.testapp.get(
         '/list_monitored_tests', {'get-sheriffed-by': 'X'})
     self.assertEqual(
-        ['TheMaster/TheBot/Suite1/aaa', 'TheMaster/TheBot/Suite1/bbb'],
+        ['TheMain/TheBot/Suite1/aaa', 'TheMain/TheBot/Suite1/bbb'],
         json.loads(response.body))
 
   def testGet_NoParameterGiven_ReturnsError(self):

--- a/src/third_party/catapult/dashboard/dashboard/list_tests.py
+++ b/src/third_party/catapult/dashboard/dashboard/list_tests.py
@@ -20,7 +20,7 @@ from dashboard.models import graph_data
 
 
 class ListTestsHandler(request_handler.RequestHandler):
-  """URL endpoint for AJAX requests to list masters, bots, and tests."""
+  """URL endpoint for AJAX requests to list mains, bots, and tests."""
 
   def post(self):
     """Outputs a JSON string of the requested list.
@@ -65,7 +65,7 @@ def GetSubTests(suite_name, bot_names):
 
   Args:
     suite_name: Top level test name.
-    bot_names: List of master/bot names in the form "<master>/<platform>".
+    bot_names: List of main/bot names in the form "<main>/<platform>".
 
   Returns:
     A dict mapping test names to dicts to entries which have the keys
@@ -76,8 +76,8 @@ def GetSubTests(suite_name, bot_names):
   # For some bots, there may be cached data; First collect and combine this.
   combined = {}
   for bot_name in bot_names:
-    master, bot = bot_name.split('/')
-    suite_key = ndb.Key('Master', master, 'Bot', bot, 'Test', suite_name)
+    main, bot = bot_name.split('/')
+    suite_key = ndb.Key('Main', main, 'Bot', bot, 'Test', suite_name)
     cached = layered_cache.Get(_ListSubTestCacheKey(suite_key))
     if cached:
       combined = _MergeSubTestsDict(combined, cached)
@@ -102,7 +102,7 @@ def _FetchSubTestPaths(test_key, deprecated):
 
   Returns:
     A list of test paths for all descendant Test entities that have associated
-    Row entities. These test paths omit the Master/bot/suite part.
+    Row entities. These test paths omit the Main/bot/suite part.
   """
   query = graph_data.Test.query(ancestor=test_key)
   query = query.filter(graph_data.Test.has_rows == True,
@@ -124,7 +124,7 @@ def _SubTestsDict(paths, deprecated):
 
   Args:
     paths: An iterable of test paths for which there are points. Each test
-        path is of the form "Master/bot/benchmark/chart/...". Each test path
+        path is of the form "Main/bot/benchmark/chart/...". Each test path
         corresponds to a Test entity for which has_rows is set to True.
     deprecated: Whether test are deprecated.
 
@@ -161,8 +161,8 @@ def _SubTestsDictEntry(sub_test_paths, has_rows, deprecated):
 def _ListSubTestCacheKey(test_key):
   """Returns the sub-tests list cache key for a test suite."""
   parts = utils.TestPath(test_key).split('/')
-  master, bot, suite = parts[0:3]
-  return graph_data.LIST_TESTS_SUBTEST_CACHE_KEY % (master, bot, suite)
+  main, bot, suite = parts[0:3]
+  return graph_data.LIST_TESTS_SUBTEST_CACHE_KEY % (main, bot, suite)
 
 
 def _MergeSubTestsDict(a, b):
@@ -195,7 +195,7 @@ def GetTestsMatchingPattern(pattern, only_with_rows=False, list_entities=False):
 
   For this function, it's assumed that a test path should only have up to seven
   parts. In theory, tests can be arbitrarily nested, but in practice, tests
-  are usually structured as master/bot/suite/graph/trace, and only a few have
+  are usually structured as main/bot/suite/graph/trace, and only a few have
   seven parts.
 
   Args:
@@ -207,7 +207,7 @@ def GetTestsMatchingPattern(pattern, only_with_rows=False, list_entities=False):
     A list of test paths, or test entities if list_entities is True.
   """
   property_names = [
-      'master_name', 'bot_name', 'suite_name', 'test_part1_name',
+      'main_name', 'bot_name', 'suite_name', 'test_part1_name',
       'test_part2_name', 'test_part3_name', 'test_part4_name']
   pattern_parts = pattern.split('/')
   if len(pattern_parts) > 7:

--- a/src/third_party/catapult/dashboard/dashboard/main.py
+++ b/src/third_party/catapult/dashboard/dashboard/main.py
@@ -132,7 +132,7 @@ def _AnomalyInfoDicts(anomalies, tests):
         'bug_id': anomaly_entity.bug_id or '',
         'start_revision': anomaly_entity.start_revision,
         'end_revision': anomaly_entity.end_revision,
-        'master': test.master_name,
+        'main': test.main_name,
         'bot': test.bot_name,
         'testsuite': test.suite_name,
         'test': subtest_path,

--- a/src/third_party/catapult/dashboard/dashboard/main_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/main_test.py
@@ -63,7 +63,7 @@ class MainTest(testing_common.TestCase):
     self.assertEqual(
         [
             {
-                'master': 'M',
+                'main': 'M',
                 'bot': 'b',
                 'testsuite': 't',
                 'test': 'foo',

--- a/src/third_party/catapult/dashboard/dashboard/migrate_test_names.py
+++ b/src/third_party/catapult/dashboard/dashboard/migrate_test_names.py
@@ -40,7 +40,7 @@ _TEST_COMPUTED_PROPERTIES = [
     'parent_test',
     'test_path',
     'id',
-    'master_name',
+    'main_name',
     'bot_name',
     'suite_name',
     'test_part1_name',
@@ -58,7 +58,7 @@ _TEST_DEPRECATED_PROPERTIES = [
     'overridden_gasp_modelset',
     'units_x',
     'buildername',
-    'masterid',
+    'mainid',
 ]
 _TEST_EXCLUDE = _TEST_COMPUTED_PROPERTIES + _TEST_DEPRECATED_PROPERTIES
 

--- a/src/third_party/catapult/dashboard/dashboard/migrate_test_names_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/migrate_test_names_test.py
@@ -17,7 +17,7 @@ from dashboard.models import graph_data
 from dashboard.models import sheriff
 from dashboard.models import stoppage_alert
 
-# Masters, bots and test names to add to the mock datastore.
+# Mains, bots and test names to add to the mock datastore.
 _MOCK_DATA = [
     ['ChromiumPerf', 'ChromiumWebkit'],
     ['win7', 'mac'],
@@ -101,12 +101,12 @@ class MigrateTestNamesTest(testing_common.TestCase):
     """Checks whether the current Test entities match the expected list.
 
     Args:
-      expected_tests: List of test paths without the master/bot part.
+      expected_tests: List of test paths without the main/bot part.
     """
-    for master in _MOCK_DATA[0]:
+    for main in _MOCK_DATA[0]:
       for bot in _MOCK_DATA[1]:
-        expected = ['%s/%s/%s' % (master, bot, t) for t in expected_tests]
-        bot_key = ndb.Key('Master', master, 'Bot', bot)
+        expected = ['%s/%s/%s' % (main, bot, t) for t in expected_tests]
+        bot_key = ndb.Key('Main', main, 'Bot', bot)
         tests = graph_data.Test.query(ancestor=bot_key).fetch()
         actual = [t.test_path for t in tests]
         self.assertEqual(expected, actual)
@@ -293,28 +293,28 @@ class MigrateTestNamesTest(testing_common.TestCase):
     self.assertIn('sheriffed by Perf Sheriff Win', body)
 
   def testPost_MigratesStoppageAlerts(self):
-    testing_common.AddTests(['Master'], ['b'], {'suite': {'foo': {}}})
-    test_path = 'Master/b/suite/foo'
+    testing_common.AddTests(['Main'], ['b'], {'suite': {'foo': {}}})
+    test_path = 'Main/b/suite/foo'
     test_key = utils.TestKey(test_path)
     test_container_key = utils.GetTestContainerKey(test_key)
     row_key = graph_data.Row(id=100, parent=test_container_key, value=5).put()
     stoppage_alert.CreateStoppageAlert(test_key.get(), row_key.get()).put()
     self.assertIsNotNone(
-        stoppage_alert.GetStoppageAlert('Master/b/suite/foo', 100))
+        stoppage_alert.GetStoppageAlert('Main/b/suite/foo', 100))
     self.assertIsNone(
-        stoppage_alert.GetStoppageAlert('Master/b/suite/bar', 100))
+        stoppage_alert.GetStoppageAlert('Main/b/suite/bar', 100))
 
     self.testapp.post('/migrate_test_names', {
-        'old_pattern': 'Master/b/suite/foo',
-        'new_pattern': 'Master/b/suite/bar',
+        'old_pattern': 'Main/b/suite/foo',
+        'new_pattern': 'Main/b/suite/bar',
     })
     self.ExecuteTaskQueueTasks(
         '/migrate_test_names', migrate_test_names._TASK_QUEUE_NAME)
 
     self.assertIsNotNone(
-        stoppage_alert.GetStoppageAlert('Master/b/suite/bar', 100))
+        stoppage_alert.GetStoppageAlert('Main/b/suite/bar', 100))
     self.assertIsNone(
-        stoppage_alert.GetStoppageAlert('Master/b/suite/foo', 100))
+        stoppage_alert.GetStoppageAlert('Main/b/suite/foo', 100))
 
   def testGetNewTestPath_WithAsterisks(self):
     self.assertEqual(

--- a/src/third_party/catapult/dashboard/dashboard/models/alert.py
+++ b/src/third_party/catapult/dashboard/dashboard/models/alert.py
@@ -169,5 +169,5 @@ def _GetTestSuiteFromKey(test_key):
 def GetBotNamesFromAlerts(alerts):
   """Gets a set with the names of the bots related to some alerts."""
   # a.test is a ndb.Key object, and a.test.flat() should return a list like
-  # ['Master', master name, 'Bot', bot name, 'Test', test suite name, ...]
+  # ['Main', main name, 'Bot', bot name, 'Test', test suite name, ...]
   return {a.test.flat()[3] for a in alerts}

--- a/src/third_party/catapult/dashboard/dashboard/models/graph_data_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/models/graph_data_test.py
@@ -11,8 +11,8 @@ from dashboard.models import graph_data
 class GraphDataTest(testing_common.TestCase):
 
   def testPutTestTruncatesDescription(self):
-    master = graph_data.Master(id='M').put()
-    bot = graph_data.Bot(parent=master, id='b').put()
+    main = graph_data.Main(id='M').put()
+    bot = graph_data.Bot(parent=main, id='b').put()
     long_string = 500 * 'x'
     too_long = long_string + 'y'
     key = graph_data.Test(id='a', parent=bot, description=too_long).put()

--- a/src/third_party/catapult/dashboard/dashboard/models/try_job.py
+++ b/src/third_party/catapult/dashboard/dashboard/models/try_job.py
@@ -28,7 +28,7 @@ class TryJob(internal_only_model.InternalOnlyModel):
   email = ndb.StringProperty()
   rietveld_issue_id = ndb.IntegerProperty()
   rietveld_patchset_id = ndb.IntegerProperty()
-  master_name = ndb.StringProperty(default='ChromiumPerf', indexed=False)
+  main_name = ndb.StringProperty(default='ChromiumPerf', indexed=False)
   buildbucket_job_id = ndb.StringProperty()
   use_buildbucket = ndb.BooleanProperty(default=False, indexed=True)
   internal_only = ndb.BooleanProperty(default=False, indexed=True)

--- a/src/third_party/catapult/dashboard/dashboard/mr.py
+++ b/src/third_party/catapult/dashboard/dashboard/mr.py
@@ -155,7 +155,7 @@ def _MarkDeprecated(test):
   # on whether tests are deprecated, so when a new suite is deprecated,
   # the cache needs to be cleared.
   layered_cache.Delete(graph_data.LIST_TESTS_SUBTEST_CACHE_KEY % (
-      test.master_name, test.bot_name, test.suite_name))
+      test.main_name, test.bot_name, test.suite_name))
 
   # Check whether the test suite now contains only deprecated tests, and
   # if so, deprecate it too.

--- a/src/third_party/catapult/dashboard/dashboard/new_points_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/new_points_test.py
@@ -58,8 +58,8 @@ class NewPointsTest(testing_common.TestCase):
 
   def _AddInternalSampleData(self):
     """Adds some internal-only test data."""
-    master = graph_data.Master(id='XMaster').put()
-    bot = graph_data.Bot(id='x-bot', parent=master, internal_only=True).put()
+    main = graph_data.Main(id='XMain').put()
+    bot = graph_data.Bot(id='x-bot', parent=main, internal_only=True).put()
     test = graph_data.Test(id='xtest', parent=bot, internal_only=True).put()
     test_container_key = utils.GetTestContainerKey(test)
     for i in range(50):
@@ -85,7 +85,7 @@ class NewPointsTest(testing_common.TestCase):
     # When the users' query pattern has no matching test, the user should be
     # notified that this is the case.
     response = self.testapp.get('/new_points',
-                                {'pattern': 'ImaginaryMaster/*/*/mytest'})
+                                {'pattern': 'ImaginaryMain/*/*/mytest'})
     self.assertTrue('No tests matching pattern' in response.body)
     self.assertEqual(1, len(re.findall(r'<tr>', response.body)))
 
@@ -110,8 +110,8 @@ class NewPointsTest(testing_common.TestCase):
     self.assertEqual(1, len(re.findall(r'<tr>', response.body)))
 
   def testGet_WithMaxTestsParam(self):
-    master = graph_data.Master(id='XMaster').put()
-    bot = graph_data.Bot(id='x-bot', parent=master).put()
+    main = graph_data.Main(id='XMain').put()
+    bot = graph_data.Bot(id='x-bot', parent=main).put()
     for i in range(20):
       test = graph_data.Test(id='xtest-%d' % i, parent=bot).put()
       test_container_key = utils.GetTestContainerKey(test)

--- a/src/third_party/catapult/dashboard/dashboard/post_data_handler.py
+++ b/src/third_party/catapult/dashboard/dashboard/post_data_handler.py
@@ -11,7 +11,7 @@ from dashboard import utils
 
 
 class PostDataHandler(request_handler.RequestHandler):
-  """Helper class to handle common functionality for dealing with slaves."""
+  """Helper class to handle common functionality for dealing with subordinates."""
 
   def post(self):
     """Checks the IP of the request against the white list.

--- a/src/third_party/catapult/dashboard/dashboard/post_data_handler_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/post_data_handler_test.py
@@ -12,7 +12,7 @@ from dashboard import post_data_handler
 from dashboard import testing_common
 
 _SAMPLE_POINT = {
-    'master': 'ChromiumPerf',
+    'main': 'ChromiumPerf',
     'bot': 'win7',
     'test': 'foo/bar/baz',
     'revision': '12345',

--- a/src/third_party/catapult/dashboard/dashboard/report.py
+++ b/src/third_party/catapult/dashboard/dashboard/report.py
@@ -44,18 +44,18 @@ class ReportHandler(chart_handler.ChartHandler):
     Returns:
       A query string if request parameters are from old URI, otherwise None.
     """
-    masters = self.request.get('masters')
+    mains = self.request.get('mains')
     bots = self.request.get('bots')
     tests = self.request.get('tests')
     checked = self.request.get('checked')
 
-    if not (masters and bots and tests):
+    if not (mains and bots and tests):
       return None
 
     # Page state is a list of chart state.  Chart state is
     # a list of pair of test path and selected series which is used
     # to generate a chart on /report page.
-    state = _CreatePageState(masters, bots, tests, checked)
+    state = _CreatePageState(mains, bots, tests, checked)
 
     # Replace default separators to remove whitespace.
     state_json = json.dumps(state, separators=(',', ':'))
@@ -75,15 +75,15 @@ class ReportHandler(chart_handler.ChartHandler):
     return query_string
 
 
-def _CreatePageState(masters, bots, tests, checked):
+def _CreatePageState(mains, bots, tests, checked):
   """Creates a page state dictionary for old URI parameters.
 
-  Based on original /report page, each combination of masters, bots, and
+  Based on original /report page, each combination of mains, bots, and
   tests is a chart; therefor we create a list of chart states for those
   combinations.
 
   Args:
-    masters: A string with comma separated list of masters.
+    mains: A string with comma separated list of mains.
     bots: A string with comma separated list of bots.
     tests: A string with comma separated list of tests.
     checked: A string with comma separated list of checked series.
@@ -98,21 +98,21 @@ def _CreatePageState(masters, bots, tests, checked):
     else:
       selected_series = checked.split(',')
 
-  masters = masters.split(',')
+  mains = mains.split(',')
   bots = bots.split(',')
   tests = tests.split(',')
   test_paths = []
-  for master in masters:
+  for main in mains:
     for bot in bots:
       for test in tests:
         test_parts = test.split('/')
         if len(test_parts) == 1:
-          first_test = _GetFirstTest(test, master + '/' + bot)
+          first_test = _GetFirstTest(test, main + '/' + bot)
           if first_test:
             test += '/' + first_test
             if not selected_series:
               selected_series.append(first_test)
-        test_paths.append(master + '/' + bot + '/' + test)
+        test_paths.append(main + '/' + bot + '/' + test)
 
   chart_states = []
   for path in test_paths:
@@ -128,7 +128,7 @@ def _GetFirstTest(test_suite, bot_path):
 
   Args:
     test_suite: Test suite name.
-    bot_path: Master and bot name separated by a slash.
+    bot_path: Main and bot name separated by a slash.
 
   Returns:
     The first test that has rows, otherwise returns None.

--- a/src/third_party/catapult/dashboard/dashboard/report_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/report_test.py
@@ -28,7 +28,7 @@ class ReportTest(testing_common.TestCase):
   def _AddTestSuites(self):
     """Adds sample data and sets the list of test suites."""
     # Mock out some data for a test.
-    masters = [
+    mains = [
         'ChromiumPerf',
         'ChromiumGPU',
     ]
@@ -47,11 +47,11 @@ class ReportTest(testing_common.TestCase):
         },
         'dromaeo': {},
     }
-    testing_common.AddTests(masters, bots, tests)
-    for m in masters:
+    testing_common.AddTests(mains, bots, tests)
+    for m in mains:
       for b in bots:
         for t in tests:
-          t = ndb.Key('Master', m, 'Bot', b, 'Test', t).get()
+          t = ndb.Key('Main', m, 'Bot', b, 'Test', t).get()
           t.description = 'This should show up'
           t.put()
 
@@ -109,7 +109,7 @@ class ReportTest(testing_common.TestCase):
 
     response = self.testapp.get(
         '/report'
-        '?masters=ChromiumGPU&bots=linux,win'
+        '?mains=ChromiumGPU&bots=linux,win'
         '&tests=scrolling/num_layers,scrolling/num_layers/about.com'
         '&checked=num_layers')
 
@@ -125,7 +125,7 @@ class ReportTest(testing_common.TestCase):
   def testGet_OldUriMissingTestParam(self):
     response = self.testapp.get(
         '/report'
-        '?masters=ChromiumGPU&bots=linux,win'
+        '?mains=ChromiumGPU&bots=linux,win'
         '&checked=num_layers')
 
     location = response.headers.get('location')
@@ -150,7 +150,7 @@ class ReportTest(testing_common.TestCase):
 
     response = self.testapp.get(
         '/report'
-        '?masters=ChromiumGPU&bots=linux-release'
+        '?mains=ChromiumGPU&bots=linux-release'
         '&tests=scrolling_benchmark')
 
     # We expect to get a URL redirect with an sid.
@@ -165,7 +165,7 @@ class ReportTest(testing_common.TestCase):
   def testGet_OldUriWithRevisionParams(self):
     response = self.testapp.get(
         '/report'
-        '?masters=ChromiumGPU&bots=linux,win'
+        '?mains=ChromiumGPU&bots=linux,win'
         '&tests=scrolling/num_layers,scrolling/num_layers/about.com'
         '&checked=num_layers&start_rev=1234&end_rev=5678')
     location = response.headers.get('location')

--- a/src/third_party/catapult/dashboard/dashboard/rietveld_service.py
+++ b/src/third_party/catapult/dashboard/dashboard/rietveld_service.py
@@ -219,14 +219,14 @@ class RietveldService(object):
       return (None, None)
     return issue_id, patchset_id
 
-  def TryPatch(self, tryserver_master, issue_id, patchset_id, bot):
+  def TryPatch(self, tryserver_main, issue_id, patchset_id, bot):
     """Sends a request to try the given patchset on the given trybot.
 
     To see exactly how this request is handled, you can see the try_patchset
     handler in the Chromium branch of Rietveld: http://goo.gl/U6tJQZ
 
     Args:
-      tryserver_master: Master name, e.g. "tryserver.chromium.perf".
+      tryserver_main: Main name, e.g. "tryserver.chromium.perf".
       issue_id: Rietveld issue ID.
       patchset_id: Patchset ID (returned when a patch is uploaded).
       bot: Bisect bot name.
@@ -237,7 +237,7 @@ class RietveldService(object):
     args = {
         'xsrf_token': self._XsrfToken(),
         'builders': json.dumps({bot: ['defaulttests']}),
-        'master': tryserver_master,
+        'main': tryserver_main,
         'reason': 'Perf bisect',
         'clobber': 'False',
     }

--- a/src/third_party/catapult/dashboard/dashboard/shrink_timestamp_revisions.py
+++ b/src/third_party/catapult/dashboard/dashboard/shrink_timestamp_revisions.py
@@ -13,7 +13,7 @@ commit positions as x-values, but want to keep all of the existing data
 there, in order.
 
 Therefore, we want to change all revision numbers of points under the
-ChromiumWebRTC and ChromiumWebRTCFYI masters to use modified x-values.
+ChromiumWebRTC and ChromiumWebRTCFYI mains to use modified x-values.
 
 TODO(qyearsley): Remove this handler (and its related entries in BUILD and
 dispatcher.py) when http://crbug.com/496048 (and http://crbug.com/469523)

--- a/src/third_party/catapult/dashboard/dashboard/start_try_job_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/start_try_job_test.py
@@ -336,7 +336,7 @@ class StartBisectTest(testing_common.TestCase):
         })
     namespaced_stored_object.Set(
         start_try_job._BUILDER_TYPES_KEY,
-        {'ChromiumPerf': 'perf', 'OtherMaster': 'foo'})
+        {'ChromiumPerf': 'perf', 'OtherMain': 'foo'})
     namespaced_stored_object.Set(
         start_try_job._BOT_BROWSER_MAP_KEY,
         [
@@ -409,7 +409,7 @@ class StartBisectTest(testing_common.TestCase):
     self.assertEqual('foo@chromium.org', info['email'])
     self.assertEqual('page_cycler.morejs', info['suite'])
     self.assertEqual('times/page_load_time', info['default_metric'])
-    self.assertEqual('ChromiumPerf', info['master'])
+    self.assertEqual('ChromiumPerf', info['main'])
     self.assertFalse(info['internal_only'])
     self.assertTrue(info['use_archive'])
     self.assertEqual(
@@ -482,7 +482,7 @@ class StartBisectTest(testing_common.TestCase):
     self._TestGetBisectConfig(
         {
             'bisect_bot': 'linux_perf_bisect',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'suite': 'page_cycler.moz',
             'metric': 'times/page_load_time',
             'good_revision': '265549',
@@ -512,7 +512,7 @@ class StartBisectTest(testing_common.TestCase):
     self._TestGetBisectConfig(
         {
             'bisect_bot': 'linux_perf_tester',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'suite': 'page_cycler.moz',
             'metric': 'times/page_load_time',
             'good_revision': '265549',
@@ -546,7 +546,7 @@ class StartBisectTest(testing_common.TestCase):
     self._TestGetBisectConfig(
         {
             'bisect_bot': 'linux_perf_bisect',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'suite': 'page_cycler.moz',
             'metric': 'times/page_load_time',
             'good_revision': '265549',
@@ -576,7 +576,7 @@ class StartBisectTest(testing_common.TestCase):
     self._TestGetBisectConfig(
         {
             'bisect_bot': 'win_perf_bisect',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'suite': 'page_cycler.morejs',
             'metric': 'times/page_load_time',
             'good_revision': '12345',
@@ -605,7 +605,7 @@ class StartBisectTest(testing_common.TestCase):
     self._TestGetBisectConfig(
         {
             'bisect_bot': 'linux_perf_bisect',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'suite': 'page_cycler.moz',
             'metric': 'times/page_load_time',
             'good_revision': '265549',
@@ -638,7 +638,7 @@ class StartBisectTest(testing_common.TestCase):
         {
             'bisect_bot': 'linux_perf_bisect',
             'suite': 'page_cycler.moz',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'metric': 'times/page_load_time',
             'good_revision': '265549',
             'bad_revision': '265556',
@@ -691,26 +691,26 @@ class StartBisectTest(testing_common.TestCase):
   def testGuessBisectBot_FetchesNameFromBisectBotMap(self):
     namespaced_stored_object.Set(
         start_try_job._BISECT_BOT_MAP_KEY,
-        {'OtherMaster': [('foo', 'super_foo_bisect_bot')]})
+        {'OtherMain': [('foo', 'super_foo_bisect_bot')]})
     self.assertEqual(
         'super_foo_bisect_bot',
-        start_try_job.GuessBisectBot('OtherMaster', 'foo'))
+        start_try_job.GuessBisectBot('OtherMain', 'foo'))
 
   def testGuessBisectBot_PlatformNotFound_UsesFallback(self):
     namespaced_stored_object.Set(
         start_try_job._BISECT_BOT_MAP_KEY,
-        {'OtherMaster': [('foo', 'super_foo_bisect_bot')]})
+        {'OtherMain': [('foo', 'super_foo_bisect_bot')]})
     self.assertEqual(
         'linux_perf_bisect',
-        start_try_job.GuessBisectBot('OtherMaster', 'bar'))
+        start_try_job.GuessBisectBot('OtherMain', 'bar'))
 
-  def testGuessBisectBot_TreatsMasterNameAsPrefix(self):
+  def testGuessBisectBot_TreatsMainNameAsPrefix(self):
     namespaced_stored_object.Set(
         start_try_job._BISECT_BOT_MAP_KEY,
-        {'OtherMaster': [('foo', 'super_foo_bisect_bot')]})
+        {'OtherMain': [('foo', 'super_foo_bisect_bot')]})
     self.assertEqual(
         'super_foo_bisect_bot',
-        start_try_job.GuessBisectBot('OtherMasterFyi', 'foo'))
+        start_try_job.GuessBisectBot('OtherMainFyi', 'foo'))
 
   @mock.patch.object(start_try_job.buildbucket_service, 'PutJob',
                      mock.MagicMock(return_value='1234567'))
@@ -744,7 +744,7 @@ class StartBisectTest(testing_common.TestCase):
     bisect_job = try_job.TryJob(
         bot='foo',
         config='config = {}',
-        master_name='ChromiumPerf',
+        main_name='ChromiumPerf',
         internal_only=False,
         job_type='bisect',
         use_buildbucket=True)
@@ -922,7 +922,7 @@ class StartBisectTest(testing_common.TestCase):
     self._TestGetBisectConfig(
         {
             'bisect_bot': 'win_perf_bisect',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'suite': 'page_cycler.morejs',
             'metric': 'times/page_load_time',
             'good_revision': '12345',
@@ -952,7 +952,7 @@ class StartBisectTest(testing_common.TestCase):
     self._TestGetBisectConfig(
         {
             'bisect_bot': 'win_x64_perf_bisect',
-            'master_name': 'ChromiumPerf',
+            'main_name': 'ChromiumPerf',
             'suite': 'page_cycler.moz',
             'metric': 'times/page_load_time',
             'good_revision': '265549',

--- a/src/third_party/catapult/dashboard/dashboard/stats.py
+++ b/src/third_party/catapult/dashboard/dashboard/stats.py
@@ -103,8 +103,8 @@ class StatsHandler(request_handler.RequestHandler):
 
   def _DisplayForm(self):
     """Displays a form for requesting a set of statistics."""
-    master = ndb.Key('Master', 'ChromiumPerf')
-    bots = graph_data.Bot.query(ancestor=master).fetch(keys_only=True)
+    main = ndb.Key('Main', 'ChromiumPerf')
+    bots = graph_data.Bot.query(ancestor=main).fetch(keys_only=True)
     bots = [b.string_id() for b in bots]
     sheriffs = sheriff.Sheriff.query().fetch(keys_only=True)
     sheriffs = [s.string_id() for s in sheriffs]
@@ -240,9 +240,9 @@ class StatsHandler(request_handler.RequestHandler):
   def _StartGeneratingStatsAroundRevision(self, stat_container):
     """Adds tasks for generating around_revision stats to the task queue.
 
-    Note: Master and sheriff are hard-coded below. If we want to use this
-    to generate stats about other masters or sheriffs, we should:
-      1. Make master and sheriff specified by parameters.
+    Note: Main and sheriff are hard-coded below. If we want to use this
+    to generate stats about other mains or sheriffs, we should:
+      1. Make main and sheriff specified by parameters.
       2. Add fields on the form to specify these parameters.
 
     Args:

--- a/src/third_party/catapult/dashboard/dashboard/test_owner.py
+++ b/src/third_party/catapult/dashboard/dashboard/test_owner.py
@@ -6,8 +6,8 @@
 
 We want to allow editing test ownership through incoming chart metadata as well
 as through dashboard UI, so we keep track of changes in test ownership that come
-in from incoming chart metadata and apply them to a master copy of the test
-owners data.  The dashboard UI, on the other hand, can modify the master copy
+in from incoming chart metadata and apply them to a main copy of the test
+owners data.  The dashboard UI, on the other hand, can modify the main copy
 directly.
 
 Test owners data are stored in layered_cache as dictionary of test suite path to
@@ -22,7 +22,7 @@ from dashboard import layered_cache
 
 # Cache keys for layered cache test owner dictionary.
 _CHARTJSON_OWNER_CACHE_KEY = 'ChartjsonOwner'
-_MASTER_OWNER_CACHE_KEY = 'MasterOwner'
+_MASTER_OWNER_CACHE_KEY = 'MainOwner'
 
 _MAX_TEST_SUITE_PATH_LENGTH = 500
 _MAX_OWNER_EMAIL_LENGTH = 254
@@ -32,10 +32,10 @@ def UpdateOwnerFromChartjson(owner_dict):
   """Updates test owners with test owner data from chartjson.
 
   Checks if tests owners have changed by matching |owner_dict| with the stored
-  owner dict for chartjson and update the master owner dict accordingly.
+  owner dict for chartjson and update the main owner dict accordingly.
 
   Args:
-    owner_dict: A dictionary of Master/Test suite to set of owners.
+    owner_dict: A dictionary of Main/Test suite to set of owners.
   """
   add_owner_dict = {}
   remove_owner_dict = {}
@@ -71,15 +71,15 @@ def AddOwner(test_suite_path, owner_email):
   """Adds an owner for a test suite path.
 
   Args:
-    test_suite_path: A string of "Master/Test suite".
+    test_suite_path: A string of "Main/Test suite".
     owner_email: An email string.
   """
-  owner_dict_cache = GetMasterCachedOwner()
+  owner_dict_cache = GetMainCachedOwner()
   owners = owner_dict_cache.get(test_suite_path, set())
   owners.add(owner_email)
   owner_dict_cache[test_suite_path] = owners
   layered_cache.SetExternal(_MASTER_OWNER_CACHE_KEY, owner_dict_cache)
-  owner_dict_cache = GetMasterCachedOwner()
+  owner_dict_cache = GetMainCachedOwner()
 
 
 def AddOwnerFromDict(owner_dict):
@@ -103,9 +103,9 @@ def AddOwnerFromDict(owner_dict):
     }
 
   Args:
-    owner_dict: A dictionary of "Master/Test suite" to set of owners' email.
+    owner_dict: A dictionary of "Main/Test suite" to set of owners' email.
   """
-  owner_dict_cache = GetMasterCachedOwner()
+  owner_dict_cache = GetMainCachedOwner()
   for path, owners in owner_dict.iteritems():
     owners_cache = owner_dict_cache.get(path, set())
     owners_cache.update(owners)
@@ -117,11 +117,11 @@ def RemoveOwner(test_suite_path, owner_email=None):
   """Removes test owners for |test_suite_path|.
 
   Args:
-    test_suite_path: A string of "Master/Test suite".
+    test_suite_path: A string of "Main/Test suite".
     owner_email: Optional email string.  If not specified, dict entry
         for |test_suite_path| will be deleted.
   """
-  owner_dict_cache = GetMasterCachedOwner()
+  owner_dict_cache = GetMainCachedOwner()
   if test_suite_path in owner_dict_cache:
     if owner_email:
       owners = owner_dict_cache[test_suite_path]
@@ -137,10 +137,10 @@ def RemoveOwnerFromDict(owner_dict):
   """Adds test owner from |owner_dict| to owner dict in layered_cache.
 
   Args:
-    owner_dict: A dictionary of Master/Test suite to set of owners to be
+    owner_dict: A dictionary of Main/Test suite to set of owners to be
         removed.
   """
-  owner_dict_cache = GetMasterCachedOwner()
+  owner_dict_cache = GetMainCachedOwner()
   for path, owners in owner_dict.iteritems():
     owners_cache = owner_dict_cache.get(path, set())
     owner_dict_cache[path] = owners_cache - owners
@@ -152,7 +152,7 @@ def RemoveOwnerFromDict(owner_dict):
 def GetOwners(test_suite_paths):
   """Gets a list of owners for a list of test suite paths."""
   owners = set()
-  owner_dict_cache = GetMasterCachedOwner()
+  owner_dict_cache = GetMainCachedOwner()
   for path in test_suite_paths:
     if path in owner_dict_cache:
       owners.update(owner_dict_cache[path])
@@ -162,14 +162,14 @@ def GetOwners(test_suite_paths):
 def GetTestSuitePaths(owner_email):
   """Gets a list of test suite paths for an owner."""
   test_suite_paths = []
-  owner_dict_cache = GetMasterCachedOwner()
+  owner_dict_cache = GetMainCachedOwner()
   for path, owners in owner_dict_cache.iteritems():
     if owner_email in owners:
       test_suite_paths.append(path)
   return sorted(test_suite_paths)
 
 
-def GetMasterCachedOwner():
+def GetMainCachedOwner():
   """Gets test owner cached dictionary from layered_cache."""
   return layered_cache.GetExternal(_MASTER_OWNER_CACHE_KEY) or {}
 

--- a/src/third_party/catapult/dashboard/dashboard/test_owner_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/test_owner_test.py
@@ -79,7 +79,7 @@ class TestOwnerTest(testing_common.TestCase):
         'ChromiumPerf/speedometer': {'dan@chromium.org'},
         'ChromiumPerf/jetstream': {'michael@chromium.org'},
     }
-    master_owner_dict_cache = {
+    main_owner_dict_cache = {
         'ChromiumPerf/speedometer':
             {'chris@google.com', 'chris@chromium.org', 'dan@chromium.org'},
         'ChromiumPerf/jetstream': {'michael@chromium.org'},
@@ -94,7 +94,7 @@ class TestOwnerTest(testing_common.TestCase):
     layered_cache.SetExternal(
         test_owner._CHARTJSON_OWNER_CACHE_KEY, chartjson_owner_dict_cache)
     layered_cache.SetExternal(
-        test_owner._MASTER_OWNER_CACHE_KEY, master_owner_dict_cache)
+        test_owner._MASTER_OWNER_CACHE_KEY, main_owner_dict_cache)
 
     test_owner.UpdateOwnerFromChartjson(new_chartjson_owner_dict)
 
@@ -102,9 +102,9 @@ class TestOwnerTest(testing_common.TestCase):
         test_owner._CHARTJSON_OWNER_CACHE_KEY)
     self.assertEqual(_ANOTHER_SAMPLE_OWNER_DICT, updated_chartjson_owner_dict)
 
-    updated_master_owner_dict = layered_cache.GetExternal(
+    updated_main_owner_dict = layered_cache.GetExternal(
         test_owner._MASTER_OWNER_CACHE_KEY)
-    self.assertEqual(_COMBINED_SAMPLE_OWNER_DICT, updated_master_owner_dict)
+    self.assertEqual(_COMBINED_SAMPLE_OWNER_DICT, updated_main_owner_dict)
 
 
 if __name__ == '__main__':

--- a/src/third_party/catapult/dashboard/dashboard/testing_common.py
+++ b/src/third_party/catapult/dashboard/dashboard/testing_common.py
@@ -101,19 +101,19 @@ class TestCase(unittest.TestCase):
     return None
 
 
-def AddTests(masters, bots, tests_dict):
+def AddTests(mains, bots, tests_dict):
   """Adds data to the mock datastore.
 
   Args:
-    masters: List of buildbot master names.
+    mains: List of buildbot main names.
     bots: List of bot names.
     tests_dict: Nested dictionary of tests to add; keys are test names
         and values are nested dictionaries of tests to add.
   """
-  for master_name in masters:
-    master_key = graph_data.Master(id=master_name).put()
+  for main_name in mains:
+    main_key = graph_data.Main(id=main_name).put()
     for bot_name in bots:
-      bot_key = graph_data.Bot(id=bot_name, parent=master_key).put()
+      bot_key = graph_data.Bot(id=bot_name, parent=main_key).put()
       for test_name in tests_dict:
         test_key = graph_data.Test(id=test_name, parent=bot_key).put()
         _AddSubtest(test_key, tests_dict[test_name])

--- a/src/third_party/catapult/dashboard/dashboard/update_bug_with_results.py
+++ b/src/third_party/catapult/dashboard/dashboard/update_bug_with_results.py
@@ -413,7 +413,7 @@ def _GetBotFailureInfo(build_data):
 
   # Add failed steps message.
   # 'text' field has the following properties:
-  #   text":["failed","slave_steps","failed","Working on [b92af3931458f2]"]
+  #   text":["failed","subordinate_steps","failed","Working on [b92af3931458f2]"]
   status_list = build_data['text']
   if status_list[0] == 'failed':
     message += 'Failed steps: %s\n\n' % ', '.join(status_list[1::2])
@@ -628,8 +628,8 @@ def _CheckBisectBotForInfraFailure(bug_id, build_data, build_url):
   build_steps = build_data['steps']
 
   # If there's no bisect scripts step then it is considered infra issue.
-  slave_step_index = _GetBisectScriptStepIndex(build_steps)
-  if not slave_step_index:
+  subordinate_step_index = _GetBisectScriptStepIndex(build_steps)
+  if not subordinate_step_index:
     _LogBisectInfraFailure(bug_id, 'Bot failure.', build_url)
     return
 
@@ -648,9 +648,9 @@ def _CheckBisectBotForInfraFailure(bug_id, build_data, build_url):
       'Failed to sync',
       'Failed to run [gclient runhooks]',
   ]
-  slave_step = build_steps[slave_step_index]
+  subordinate_step = build_steps[subordinate_step_index]
   stdio_url = ('%s/steps/%s/logs/stdio/text' %
-               (build_url, urllib.quote(slave_step['name'])))
+               (build_url, urllib.quote(subordinate_step['name'])))
   response = _FetchURL(stdio_url)
   if response:
     for flag in build_failure_flags:
@@ -663,7 +663,7 @@ def _GetBisectScriptStepIndex(build_steps):
   """Gets the index of step that run bisect script in build step data."""
   index = 0
   for step in build_steps:
-    if step['name'] in ['slave_steps', 'Running Bisection']:
+    if step['name'] in ['subordinate_steps', 'Running Bisection']:
       return index
     index += 1
   return None

--- a/src/third_party/catapult/dashboard/dashboard/update_bug_with_results_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/update_bug_with_results_test.py
@@ -182,7 +182,7 @@ Bisect job ran on: win_perf_bisect
 Completed 1/2 builds.
 Run time: 724/720 minutes.
 Bisect timed out! Try again with a smaller revision range.
-Failed steps: slave_steps, Working on def
+Failed steps: subordinate_steps, Working on def
 
 ===== PARTIAL RESULTS =====
 Depot Commit SHA Mean Std. Error State
@@ -375,7 +375,7 @@ def _MockFetch(url=None):
               'steps': [{'name': 'Working on abc', 'results': [0]},
                         {'name': 'Working on def', 'results': [2]}],
               'times': [1411501756.293642, 1411545237.89049],
-              'text': ['failed', 'slave_steps', 'failed', 'Working on def']})
+              'text': ['failed', 'subordinate_steps', 'failed', 'Working on def']})
       ],
       'http://build.chromium.org/bb1234567/steps/Results/logs/stdio/text': [
           200, _BISECT_LOG_SINGLE_OWNER
@@ -386,7 +386,7 @@ def _MockFetch(url=None):
               'steps': [{'name': 'Working on abc', 'results': [0]},
                         {'name': 'Working on def', 'results': [2]}],
               'times': [1411501756.293642, 1411545237.89049],
-              'text': ['failed', 'slave_steps', 'failed', 'Working on def']})
+              'text': ['failed', 'subordinate_steps', 'failed', 'Working on def']})
       ],
       ('http://build.chromium.org/builders/bb66666'
        '/steps/Results/logs/stdio/text'): [
@@ -845,7 +845,7 @@ class UpdateBugWithResultsTest(testing_common.TestCase):
     bug_id = 516
     build_data = {
         'steps': [{'name': 'A', 'results': [0]},
-                  {'name': 'slave_steps', 'results': [2]}],
+                  {'name': 'subordinate_steps', 'results': [2]}],
         'times': [1411500000, 1411501000],
     }
     build_url = 'http://build.chromium.org/builders/516'

--- a/src/third_party/catapult/dashboard/dashboard/update_test_suites.py
+++ b/src/third_party/catapult/dashboard/dashboard/update_test_suites.py
@@ -78,18 +78,18 @@ def _CreateTestSuiteDict():
           ...
       }
 
-    Where 'mas', 'mon', 'dep', and 'des' are abbreviations for 'masters',
+    Where 'mas', 'mon', 'dep', and 'des' are abbreviations for 'mains',
     'monitored', 'deprecated', and 'description', respectively.
   """
   suites = _FetchSuites()
-  suite_to_masters = _CreateSuiteMastersDict(suites)
+  suite_to_mains = _CreateSuiteMainsDict(suites)
   suite_to_description = _CreateSuiteDescriptionDict(suites)
   suite_to_monitored = _CreateSuiteMonitoredDict()
   nondeprecated_suites = _CreateSuiteNondeprecatedSet(suites)
 
   result = {}
-  for name in suite_to_masters:
-    result[name] = {'mas': suite_to_masters[name]}
+  for name in suite_to_mains:
+    result[name] = {'mas': suite_to_mains[name]}
     if name in suite_to_monitored:
       result[name]['mon'] = suite_to_monitored[name]
     if name in suite_to_description:
@@ -116,16 +116,16 @@ def _FetchSuites():
   return suites
 
 
-def _CreateSuiteMastersDict(suites):
-  """Returns an initial suite dict with names mapped to masters.
+def _CreateSuiteMainsDict(suites):
+  """Returns an initial suite dict with names mapped to mains.
 
   Args:
     suites: A list of entities for top-level Test entities.
 
   Returns:
     A dictionary mapping the test-suite names to dicts which just have
-    the key "masters", the value of which is a list of dicts mapping
-    master names to dict of bots.
+    the key "mains", the value of which is a list of dicts mapping
+    main names to dict of bots.
   """
   name_to_suites = {}
   for suite in suites:
@@ -136,33 +136,33 @@ def _CreateSuiteMastersDict(suites):
 
   result = {}
   for name, this_suites in name_to_suites.iteritems():
-    result[name] = _MasterToBotsToDeprecatedDict(this_suites)
+    result[name] = _MainToBotsToDeprecatedDict(this_suites)
   return result
 
 
-def _MasterToBotsToDeprecatedDict(suites):
-  """Makes a dictionary listing masters, bots and deprecated for tests.
+def _MainToBotsToDeprecatedDict(suites):
+  """Makes a dictionary listing mains, bots and deprecated for tests.
 
   Args:
     suites: A collection of test suite Test entities. All of the keys in
         this set should have the same test suite name.
 
   Returns:
-    A dictionary mapping master names to bot names to deprecated.
+    A dictionary mapping main names to bot names to deprecated.
   """
-  def MasterName(key):
+  def MainName(key):
     return key.pairs()[0][1]
 
   def BotName(key):
     return key.pairs()[1][1]
 
   result = {}
-  for master in {MasterName(s.key) for s in suites}:
+  for main in {MainName(s.key) for s in suites}:
     bot = {}
     for suite in suites:
-      if MasterName(suite.key) == master:
+      if MainName(suite.key) == main:
         bot[BotName(suite.key)] = suite.deprecated
-    result[master] = bot
+    result[main] = bot
   return result
 
 
@@ -207,14 +207,14 @@ def _FetchSuitesWithMonitoredProperty():
 def _GetTestSubPath(key):
   """Gets the part of the test path after the suite, for the given test key.
 
-  For example, for a test with the test path 'MyMaster/bot/my_suite/foo/bar',
+  For example, for a test with the test path 'MyMain/bot/my_suite/foo/bar',
   this should return 'foo/bar'.
 
   Args:
     key: The key of the Test entity.
 
   Returns:
-    Slash-separated test path part after master/bot/suite.
+    Slash-separated test path part after main/bot/suite.
   """
   return '/'.join(p[1] for p in key.pairs()[3:])
 

--- a/src/third_party/catapult/dashboard/dashboard/utils.py
+++ b/src/third_party/catapult/dashboard/dashboard/utils.py
@@ -92,7 +92,7 @@ def TestKey(test_path):
   path_parts = test_path.split('/')
   if path_parts is None:
     return None
-  key_list = [('Master', path_parts[0])]
+  key_list = [('Main', path_parts[0])]
   if len(path_parts) > 1:
     key_list += [('Bot', path_parts[1])]
   if len(path_parts) > 2:

--- a/src/third_party/catapult/dashboard/dashboard/utils_test.py
+++ b/src/third_party/catapult/dashboard/dashboard/utils_test.py
@@ -54,7 +54,7 @@ class UtilsTest(testing_common.TestCase):
         'ChromiumPerf/cros-*/dromaeo.*/Total')
     self._AssertDoesntMatch(
         'ChromiumPerf/cros-one/dromaeo.top25/Total',
-        'OtherMaster/cros-*/dromaeo.*/Total')
+        'OtherMain/cros-*/dromaeo.*/Total')
 
   def testMatchesPattern_MorePartialWildcards(self):
     # Note that the wildcard matches zero or more characters.
@@ -78,8 +78,8 @@ class UtilsTest(testing_common.TestCase):
 
   def _PutEntitiesAllExternal(self):
     """Puts entities (none internal-only) and returns the keys."""
-    master = graph_data.Master(id='M').put()
-    bot = graph_data.Bot(parent=master, id='b').put()
+    main = graph_data.Main(id='M').put()
+    bot = graph_data.Bot(parent=main, id='b').put()
     keys = [
         graph_data.Test(id='a', parent=bot, internal_only=False).put(),
         graph_data.Test(id='b', parent=bot, internal_only=False).put(),
@@ -90,8 +90,8 @@ class UtilsTest(testing_common.TestCase):
 
   def _PutEntitiesHalfInternal(self):
     """Puts entities (half internal-only) and returns the keys."""
-    master = graph_data.Master(id='M').put()
-    bot = graph_data.Bot(parent=master, id='b').put()
+    main = graph_data.Main(id='M').put()
+    bot = graph_data.Bot(parent=main, id='b').put()
     keys = [
         graph_data.Test(id='ax', parent=bot, internal_only=True).put(),
         graph_data.Test(id='a', parent=bot, internal_only=False).put(),
@@ -120,11 +120,11 @@ class UtilsTest(testing_common.TestCase):
     self.assertEqual(len(keys), len(utils.GetMulti(keys)))
 
   def testTestSuiteName_Basic(self):
-    key = utils.TestKey('Master/bot/suite-foo/sub/x/y/z')
+    key = utils.TestKey('Main/bot/suite-foo/sub/x/y/z')
     self.assertEqual('suite-foo', utils.TestSuiteName(key))
 
   def testTestSuiteName_KeyNotLongEnough_ReturnsNone(self):
-    key = ndb.Key('Master', 'M', 'Bot', 'b')
+    key = ndb.Key('Main', 'M', 'Bot', 'b')
     self.assertIsNone(utils.TestSuiteName(key))
 
   def testMinimumRange_Empty_ReturnsNone(self):

--- a/src/third_party/catapult/experimental/hardware.py
+++ b/src/third_party/catapult/experimental/hardware.py
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-"""Query build slave hardware info, and print it to stdout as csv."""
+"""Query build subordinate hardware info, and print it to stdout as csv."""
 
 import csv
 import json
@@ -18,7 +18,7 @@ _MASTERS = [
 
 
 _KEYS = [
-    'master', 'builder', 'hostname',
+    'main', 'builder', 'hostname',
 
     'os family', 'os version',
 
@@ -44,20 +44,20 @@ def main():
   writer = csv.DictWriter(sys.stdout, _KEYS)
   writer.writeheader()
 
-  for master_name in _MASTERS:
-    master_data = json.load(urllib2.urlopen(
-      'http://build.chromium.org/p/%s/json/slaves' % master_name))
+  for main_name in _MASTERS:
+    main_data = json.load(urllib2.urlopen(
+      'http://build.chromium.org/p/%s/json/subordinates' % main_name))
 
-    slaves = sorted(master_data.iteritems(), key=lambda x: x[1]['builders'])
-    for slave_name, slave_data in slaves:
-      for builder_name in slave_data['builders']:
+    subordinates = sorted(main_data.iteritems(), key=lambda x: x[1]['builders'])
+    for subordinate_name, subordinate_data in subordinates:
+      for builder_name in subordinate_data['builders']:
         row = {
-            'master': master_name,
+            'main': main_name,
             'builder': builder_name,
-            'hostname': slave_name,
+            'hostname': subordinate_name,
         }
 
-        host_data = slave_data['host']
+        host_data = subordinate_data['host']
         if host_data:
           host_data = host_data.splitlines()
           if len(host_data) > 1:
@@ -71,7 +71,7 @@ def main():
                 continue
               row[key] = value
 
-        if 'product name' not in row and slave_name.startswith('slave'):
+        if 'product name' not in row and subordinate_name.startswith('subordinate'):
           row['product name'] = 'Google Compute Engine'
 
         writer.writerow(row)

--- a/src/third_party/catapult/third_party/Paste/docs/conf.py
+++ b/src/third_party/catapult/third_party/Paste/docs/conf.py
@@ -29,8 +29,8 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.txt'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General substitutions.
 project = 'Paste'

--- a/src/third_party/catapult/third_party/Paste/paste/exceptions/errormiddleware.py
+++ b/src/third_party/catapult/third_party/Paste/paste/exceptions/errormiddleware.py
@@ -103,7 +103,7 @@ class ErrorMiddleware(object):
         if error_email is None:
             error_email = (global_conf.get('error_email')
                            or global_conf.get('admin_email')
-                           or global_conf.get('webmaster_email')
+                           or global_conf.get('webmain_email')
                            or global_conf.get('sysadmin_email'))
         self.error_email = converters.aslist(error_email)
         self.error_log = error_log

--- a/src/third_party/catapult/third_party/WebOb/docs/conf.py
+++ b/src/third_party/catapult/third_party/WebOb/docs/conf.py
@@ -6,7 +6,7 @@ version = release = pkg_resources.get_distribution('webob').version
 extensions = ['sphinx.ext.autodoc']
 
 source_suffix = '.txt' # The suffix of source filenames.
-master_doc = 'index' # The master toctree document.
+main_doc = 'index' # The main toctree document.
 
 project = 'WebOb'
 copyright = '2011, Ian Bicking and contributors'

--- a/src/third_party/catapult/third_party/beautifulsoup4/doc/source/conf.py
+++ b/src/third_party/catapult/third_party/beautifulsoup4/doc/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Beautiful Soup'

--- a/src/third_party/catapult/third_party/gsutil/gslib/addlhelp/naming.py
+++ b/src/third_party/catapult/third_party/gsutil/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/src/third_party/catapult/third_party/gsutil/gslib/commands/notification.py
+++ b/src/third_party/catapult/third_party/gsutil/gslib/commands/notification.py
@@ -126,7 +126,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://developers.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/src/third_party/catapult/third_party/gsutil/third_party/apitools/apitools/base/py/batch.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/apitools/apitools/base/py/batch.py
@@ -159,7 +159,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/src/third_party/catapult/third_party/gsutil/third_party/apitools/run_pylint.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/apitools/run_pylint.py
@@ -103,9 +103,9 @@ def get_files_for_linting(allow_limited=True):
     uses a specific commit or branch (a so-called diff base) to compare
     against for changed files. (This requires ``allow_limited=True``.)
 
-    To speed up linting on Travis pull requests against master, we manually
-    set the diff base to origin/master. We don't do this on non-pull requests
-    since origin/master will be equivalent to the currently checked out code.
+    To speed up linting on Travis pull requests against main, we manually
+    set the diff base to origin/main. We don't do this on non-pull requests
+    since origin/main will be equivalent to the currently checked out code.
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
@@ -122,11 +122,11 @@ def get_files_for_linting(allow_limited=True):
               linted.
     """
     diff_base = None
-    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+    if (os.getenv('TRAVIS_BRANCH') == 'main' and
             os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
-        # In the case of a pull request into master, we want to
-        # diff against HEAD in master.
-        diff_base = 'origin/master'
+        # In the case of a pull request into main, we want to
+        # diff against HEAD in main.
+        diff_base = 'origin/main'
     elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
         remote = os.getenv('GCLOUD_REMOTE_FOR_LINT')

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/emr/connection.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/emr/connection.py
@@ -398,8 +398,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -426,11 +426,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -461,7 +461,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -515,15 +515,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -710,15 +710,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/emr/step.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/kms/layer1.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/opsworks/layer1.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/pyami/bootstrap.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds/__init__.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds/__init__.py
@@ -139,8 +139,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -169,8 +169,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -399,8 +399,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -424,8 +424,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -563,7 +563,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -594,8 +594,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -681,8 +681,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds/dbinstance.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds/dbsnapshot.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds2/layer1.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/rds2/layer1.py
@@ -319,8 +319,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -415,9 +415,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -450,8 +450,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -534,7 +534,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -653,8 +653,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2478,7 +2478,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2606,14 +2606,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2624,7 +2624,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2658,7 +2658,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2810,8 +2810,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/redshift/layer1.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/emr/test_connection.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/emr/test_connection.py
@@ -182,7 +182,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -238,7 +238,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(response.instancegroups[0].name, "Main instance group")
         self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
         self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
@@ -566,7 +566,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -598,7 +598,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.status.state, 'TERMINATED')
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
-        self.assertEqual(response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -836,7 +836,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -853,7 +853,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -871,11 +871,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -903,14 +903,14 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -932,7 +932,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1000,5 +1000,5 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster' },
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/rds/test_connection.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/route53/test_connection.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/src/third_party/catapult/third_party/gsutil/third_party/crcmod/docs/source/conf.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/src/third_party/catapult/third_party/gsutil/third_party/oauth2client/docs/conf.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/oauth2client/docs/conf.py
@@ -17,7 +17,7 @@ extensions = [
 ]
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 # General information about the project.
 project = u'oauth2client'

--- a/src/third_party/catapult/third_party/gsutil/third_party/rsa/doc/conf.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/rsa/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Python-RSA'

--- a/src/third_party/catapult/third_party/gsutil/third_party/six/documentation/conf.py
+++ b/src/third_party/catapult/third_party/gsutil/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"

--- a/src/third_party/catapult/third_party/html5lib-python/doc/conf.py
+++ b/src/third_party/catapult/third_party/html5lib-python/doc/conf.py
@@ -37,8 +37,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = 'html5lib'

--- a/src/third_party/catapult/third_party/six/documentation/conf.py
+++ b/src/third_party/catapult/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"

--- a/src/third_party/catapult/third_party/typ/typ/arg_parser.py
+++ b/src/third_party/catapult/third_party/typ/typ/arg_parser.py
@@ -96,8 +96,8 @@ class ArgumentParser(argparse.ArgumentParser):
             self.add_argument('--coverage-show-missing', action='store_true',
                               help=('Show missing line ranges in coverage '
                                     'report.'))
-            self.add_argument('--master-name',
-                              help=('Buildbot master name to include in the '
+            self.add_argument('--main-name',
+                              help=('Buildbot main name to include in the '
                                     'uploaded data.'))
             self.add_argument('--metadata', action='append', default=[],
                               help=('Optional key=value metadata that will '
@@ -184,8 +184,8 @@ class ArgumentParser(argparse.ArgumentParser):
                 self._print_message('Error: --builder-name must be specified '
                                     'along with --test-result-server')
                 self.exit_status = 2
-            if not rargs.master_name:
-                self._print_message('Error: --master-name must be specified '
+            if not rargs.main_name:
+                self._print_message('Error: --main-name must be specified '
                                     'along with --test-result-server')
                 self.exit_status = 2
             if not rargs.test_type:

--- a/src/third_party/catapult/third_party/typ/typ/json_results.py
+++ b/src/third_party/catapult/third_party/typ/typ/json_results.py
@@ -104,11 +104,11 @@ def make_full_results(metadata, seconds_since_epoch, all_test_names, results):
     return full_results
 
 
-def make_upload_request(test_results_server, builder, master, testtype,
+def make_upload_request(test_results_server, builder, main, testtype,
                         full_results):
     url = 'http://%s/testfile/upload' % test_results_server
     attrs = [('builder', builder),
-             ('master', master),
+             ('main', main),
              ('testtype', testtype)]
     content_type, data = _encode_multipart_form_data(attrs, full_results)
     return url, content_type, data

--- a/src/third_party/catapult/third_party/typ/typ/runner.py
+++ b/src/third_party/catapult/third_party/typ/typ/runner.py
@@ -612,7 +612,7 @@ class Runner(object):
 
         url, content_type, data = json_results.make_upload_request(
             self.args.test_results_server, self.args.builder_name,
-            self.args.master_name, self.args.test_type,
+            self.args.main_name, self.args.test_type,
             full_results)
 
         try:

--- a/src/third_party/catapult/third_party/typ/typ/tests/json_results_test.py
+++ b/src/third_party/catapult/third_party/typ/typ/tests/json_results_test.py
@@ -24,7 +24,7 @@ class TestMakeUploadRequest(unittest.TestCase):
         results = json_results.ResultSet()
         full_results = json_results.make_full_results([], 0, [], results)
         url, content_type, data = json_results.make_upload_request(
-            'localhost', 'fake_builder_name', 'fake_master', 'fake_test_type',
+            'localhost', 'fake_builder_name', 'fake_main', 'fake_test_type',
             full_results)
 
         self.assertEqual(
@@ -40,9 +40,9 @@ class TestMakeUploadRequest(unittest.TestCase):
              '\r\n'
              'fake_builder_name\r\n'
              '---J-S-O-N-R-E-S-U-L-T-S---B-O-U-N-D-A-R-Y-\r\n'
-             'Content-Disposition: form-data; name="master"\r\n'
+             'Content-Disposition: form-data; name="main"\r\n'
              '\r\n'
-             'fake_master\r\n'
+             'fake_main\r\n'
              '---J-S-O-N-R-E-S-U-L-T-S---B-O-U-N-D-A-R-Y-\r\n'
              'Content-Disposition: form-data; name="testtype"\r\n'
              '\r\n'

--- a/src/third_party/catapult/third_party/typ/typ/tests/main_test.py
+++ b/src/third_party/catapult/third_party/typ/typ/tests/main_test.py
@@ -410,7 +410,7 @@ class TestCli(test_case.MainTestCase):
         self.check(['--test-results-server', 'localhost'], ret=2,
                    out=('Error: --builder-name must be specified '
                         'along with --test-result-server\n'
-                        'Error: --master-name must be specified '
+                        'Error: --main-name must be specified '
                         'along with --test-result-server\n'
                         'Error: --test-type must be specified '
                         'along with --test-result-server\n'), err='')
@@ -552,7 +552,7 @@ class TestCli(test_case.MainTestCase):
         try:
             self.check(['--test-results-server',
                         '%s:%d' % server.server_address,
-                        '--master-name', 'fake_master',
+                        '--main-name', 'fake_main',
                         '--builder-name', 'fake_builder',
                         '--test-type', 'typ_tests',
                         '--metadata', 'foo=bar'],
@@ -577,7 +577,7 @@ class TestCli(test_case.MainTestCase):
         try:
             self.check(['--test-results-server',
                         '%s:%d' % server.server_address,
-                        '--master-name', 'fake_master',
+                        '--main-name', 'fake_main',
                         '--builder-name', 'fake_builder',
                         '--test-type', 'typ_tests',
                         '--metadata', 'foo=bar'],
@@ -592,7 +592,7 @@ class TestCli(test_case.MainTestCase):
 
     def test_test_results_server_not_running(self):
         self.check(['--test-results-server', 'localhost:99999',
-                    '--master-name', 'fake_master',
+                    '--main-name', 'fake_main',
                     '--builder-name', 'fake_builder',
                     '--test-type', 'typ_tests',
                     '--metadata', 'foo=bar'],

--- a/src/third_party/catapult/third_party/webapp2/docs/conf.py
+++ b/src/third_party/catapult/third_party/webapp2/docs/conf.py
@@ -64,8 +64,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'webapp2'

--- a/src/tools/perf/page_sets/blink_memory_mobile.py
+++ b/src/tools/perf/page_sets/blink_memory_mobile.py
@@ -127,7 +127,7 @@ class BlinkMemoryMobilePageSet(story.StorySet):
     # Why: Key products.
     self.AddStory(GmailPage(page_set=self))
     self.AddStory(BlinkMemoryMobilePage(
-        'http://googlewebmastercentral.blogspot.com/2015/04/rolling-out-mobile-friendly-update.html?m=1',
+        'http://googlewebmaincentral.blogspot.com/2015/04/rolling-out-mobile-friendly-update.html?m=1',
         page_set=self,
         name='Blogger'))
     self.AddStory(BlinkMemoryMobilePage(

--- a/src/tools/perf/page_sets/key_desktop_sites.py
+++ b/src/tools/perf/page_sets/key_desktop_sites.py
@@ -631,7 +631,7 @@ class KeyDesktopSitesPageSet(story.StorySet):
       'http://costco.com',
       'http://bhphotovideo.com',
       'http://hm.com',
-      'http://ticketmaster.com',
+      'http://ticketmain.com',
       'http://jcpenney.com',
       'http://walgreens.com',
       'http://qvc.com',

--- a/src/tools/perf/page_sets/key_mobile_sites.py
+++ b/src/tools/perf/page_sets/key_mobile_sites.py
@@ -68,7 +68,7 @@ class KeyMobileSitesPageSet(story.StorySet):
     # Why: #11 (Alexa global), google property; some blogger layouts
     # have infinite scroll but more interesting.
     self.AddStory(KeyMobileSitesPage(
-      url='http://googlewebmastercentral.blogspot.com/',
+      url='http://googlewebmaincentral.blogspot.com/',
       page_set=self, name='Blogger'))
 
     # Why: #18 (Alexa global), Picked an interesting post """

--- a/src/tools/perf/page_sets/key_mobile_sites_repaint.py
+++ b/src/tools/perf/page_sets/key_mobile_sites_repaint.py
@@ -87,7 +87,7 @@ class KeyMobileSitesRepaintPageSet(story.StorySet):
     # Why: #11 (Alexa global), google property; some blogger layouts
     # have infinite scroll but more interesting.
     self.AddStory(KeyMobileSitesRepaintPage(
-      url='http://googlewebmastercentral.blogspot.com/',
+      url='http://googlewebmaincentral.blogspot.com/',
       page_set=self, name='Blogger', mode=mode, height=height, width=width))
 
     # Why: #18 (Alexa global), Picked an interesting post """

--- a/src/tools/perf/page_sets/key_mobile_sites_smooth.py
+++ b/src/tools/perf/page_sets/key_mobile_sites_smooth.py
@@ -178,7 +178,7 @@ class KeyMobileSitesSmoothPageSet(story.StorySet):
     # Why: #11 (Alexa global), google property; some blogger layouts
     # have infinite scroll but more interesting.
     self.AddStory(KeyMobileSitesSmoothPage(
-      url='http://googlewebmastercentral.blogspot.com/',
+      url='http://googlewebmaincentral.blogspot.com/',
       page_set=self, name='Blogger'))
 
     # Why: #18 (Alexa global), Picked an interesting post """

--- a/src/tools/perf/page_sets/top_7_stress.py
+++ b/src/tools/perf/page_sets/top_7_stress.py
@@ -205,7 +205,7 @@ class BlogspotPage(Top7StressPage):
 
   def __init__(self, page_set):
     super(BlogspotPage, self).__init__(
-      url='http://googlewebmastercentral.blogspot.com/',
+      url='http://googlewebmaincentral.blogspot.com/',
       page_set=page_set,
       name='Blogger')
 

--- a/src/tools/perf/page_sets/top_pages.py
+++ b/src/tools/perf/page_sets/top_pages.py
@@ -152,7 +152,7 @@ class BlogspotPage(TopPages):
   def __init__(self, page_set,
                shared_page_state_class=shared_page_state.SharedPageState):
     super(BlogspotPage, self).__init__(
-        url='http://googlewebmastercentral.blogspot.com/',
+        url='http://googlewebmaincentral.blogspot.com/',
         page_set=page_set,
         name='Blogger',
         shared_page_state_class=shared_page_state_class)

--- a/src/tools/perf/page_sets/tough_pinch_zoom_cases.py
+++ b/src/tools/perf/page_sets/tough_pinch_zoom_cases.py
@@ -119,7 +119,7 @@ class BlogSpotPage(ToughPinchZoomCasesPage):
 
   def __init__(self, page_set):
     super(BlogSpotPage, self).__init__(
-      url='http://googlewebmastercentral.blogspot.com/',
+      url='http://googlewebmaincentral.blogspot.com/',
       page_set=page_set, name='Blogger')
 
   def RunNavigateSteps(self, action_runner):

--- a/src/tools/perf/page_sets/typical_25.py
+++ b/src/tools/perf/page_sets/typical_25.py
@@ -104,7 +104,7 @@ class Typical25PageSet(story.StorySet):
       'http://www.osubeavers.com/',
       'http://walgreens.com',
       'http://colorado.edu',
-      ('http://www.ticketmaster.com/JAY-Z-and-Justin-Timberlake-tickets/artist/'
+      ('http://www.ticketmain.com/JAY-Z-and-Justin-Timberlake-tickets/artist/'
        '1837448?brand=none&tm_link=tm_homeA_rc_name2'),
       # pylint: disable=line-too-long
       'http://www.theverge.com/2013/3/5/4061684/inside-ted-the-smartest-bubble-in-the-world',

--- a/src/tools/perf/update_reference_build_unittest.py
+++ b/src/tools/perf/update_reference_build_unittest.py
@@ -62,19 +62,19 @@ class UpdateReferenceBuildUnittest(unittest.TestCase):
               'true_branch', 'v8_version\n'],
              ['win', 'stable', '41.0.2272.89', '41.0.2272.76', '03/10/15',
               '03/03/15', '827a380cfdb31aa54c8d56e63ce2c3fd8c3ba4d4', '310958',
-              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'master',
+              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'main',
               '4.1.0.21\n'],
              ['mac', 'stable', '41.0.2272.89', '41.0.2272.76', '03/10/15',
               '03/03/15', '827a380cfdb31aa54c8d56e63ce2c3fd8c3ba4d4', '310958',
-              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'master',
+              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'main',
               '4.1.0.21\n'],
              ['linux', 'stable', '41.0.2272.89', '41.0.2272.76', '03/10/15',
               '03/03/15', '827a380cfdb31aa54c8d56e63ce2c3fd8c3ba4d4', '310958',
-              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'master',
+              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'main',
               '4.1.0.21\n'],
              ['cros', 'stable', '41.0.2272.89', '41.0.2272.76', '03/10/15',
               '03/04/15', '827a380cfdb31aa54c8d56e63ce2c3fd8c3ba4d4', '310958',
-              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'master',
+              'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177', 'main',
               '4.1.0.21\n'],
              ['android', 'stable', '41.0.2272.94', '40.0.2214.109', '03/18/15',
               '02/04/15', '827a380cfdb31aa54c8d56e63ce2c3fd8c3ba4d4', '310958',
@@ -100,7 +100,7 @@ class UpdateReferenceBuildUnittest(unittest.TestCase):
                ['win', 'stable', '41.0.2272.89', '41.0.2272.76', '03/10/15',
                 '03/03/15', '827a380cfdb31aa54c8d56e63ce2c3fd8c3ba4d4',
                 '310958', 'a4d5695040a99b9b2cb196eb5b898383a274376e', '188177',
-                'master', '4.1.0.21\n']]
+                'main', '4.1.0.21\n']]
       self.assertRaises(ValueError, b._OmahaVersionsMap)
       lines = ['random', 'list', 'of', 'strings']
       self.assertRaises(ValueError, b._OmahaVersionsMap)

--- a/src/tools/telemetry/telemetry/core/cros_interface.py
+++ b/src/tools/telemetry/telemetry/core/cros_interface.py
@@ -95,13 +95,13 @@ class CrOSInterface(object):
                       '-o KbdInteractiveAuthentication=no',
                       '-o PreferredAuthentications=publickey',
                       '-o UserKnownHostsFile=/dev/null',
-                      '-o ControlMaster=no']
+                      '-o ControlMain=no']
 
     if ssh_identity:
       self._ssh_identity = os.path.abspath(os.path.expanduser(ssh_identity))
       os.chmod(self._ssh_identity, stat.S_IREAD)
 
-    # Establish master SSH connection using ControlPersist.
+    # Establish main SSH connection using ControlPersist.
     # Since only one test will be run on a remote host at a time,
     # the control socket filename can be telemetry@hostname.
     self._ssh_control_file = '/tmp/' + 'telemetry' + '@' + hostname

--- a/src/tools/telemetry/telemetry/internal/backends/remote/trybot_browser_finder.py
+++ b/src/tools/telemetry/telemetry/internal/backends/remote/trybot_browser_finder.py
@@ -220,7 +220,7 @@ class PossibleTrybotBrowser(possible_browser.PossibleBrowser):
 
     # Make sure the tree does have local commits.
     returncode, out, err = self._RunProcess(
-        ['git', 'log', 'origin/master..HEAD'])
+        ['git', 'log', 'origin/main..HEAD'])
     if not out:
       return NO_CHANGES
 
@@ -234,7 +234,7 @@ class PossibleTrybotBrowser(possible_browser.PossibleBrowser):
       return ERROR
     try:
       returncode, out, err = self._RunProcess(
-          ['git', 'branch', '--set-upstream-to', 'origin/master'])
+          ['git', 'branch', '--set-upstream-to', 'origin/main'])
       if returncode:
         logging.error('Error in git branch --set-upstream-to: %s', err)
         return ERROR

--- a/src/tools/telemetry/telemetry/internal/backends/remote/trybot_browser_finder_unittest.py
+++ b/src/tools/telemetry/telemetry/internal/backends/remote/trybot_browser_finder_unittest.py
@@ -277,11 +277,11 @@ class TrybotBrowserFinderTest(unittest.TestCase):
         (['git', 'rev-parse', '--abbrev-ref', 'HEAD'], (0, 'br', None)),
         (['git', 'update-index', '--refresh', '-q'], (0, None, None,)),
         (['git', 'diff-index', 'HEAD'], (0, '', None)),
-        (['git', 'log', 'origin/master..HEAD'], (0, '', None)),
+        (['git', 'log', 'origin/main..HEAD'], (0, '', None)),
         (['git', 'rev-parse', '--abbrev-ref', 'HEAD'], (0, 'br', None)),
         (['git', 'update-index', '--refresh', '-q'], (0, None, None,)),
         (['git', 'diff-index', 'HEAD'], (0, '', None)),
-        (['git', 'log', 'origin/master..HEAD'], (0, '', None)),
+        (['git', 'log', 'origin/main..HEAD'], (0, '', None)),
     ))
 
     browser.RunRemote()
@@ -301,7 +301,7 @@ class TrybotBrowserFinderTest(unittest.TestCase):
         (['git', 'rev-parse', '--abbrev-ref', 'HEAD'], (0, 'br', None)),
         (['git', 'update-index', '--refresh', '-q'], (0, None, None,)),
         (['git', 'diff-index', 'HEAD'], (0, '', None)),
-        (['git', 'log', 'origin/master..HEAD'], (0, 'logs here', None)),
+        (['git', 'log', 'origin/main..HEAD'], (0, 'logs here', None)),
         (['git', 'checkout', '-b', 'telemetry-tryjob'],
          (1, None, 'fatal: A branch named \'telemetry-try\' already exists.')),
     ))
@@ -325,15 +325,15 @@ class TrybotBrowserFinderTest(unittest.TestCase):
           (['git', 'rev-parse', '--abbrev-ref', 'HEAD'], (0, 'br', None)),
           (['git', 'update-index', '--refresh', '-q'], (0, None, None,)),
           (['git', 'diff-index', 'HEAD'], (0, '', None)),
-          (['git', 'log', 'origin/master..HEAD'], (0, '', None))
+          (['git', 'log', 'origin/main..HEAD'], (0, '', None))
       )
     self._ExpectProcesses(first_processes + (
         (['git', 'rev-parse', '--abbrev-ref', 'HEAD'], (0, branch, None)),
         (['git', 'update-index', '--refresh', '-q'], (0, None, None,)),
         (['git', 'diff-index', 'HEAD'], (0, '', None)),
-        (['git', 'log', 'origin/master..HEAD'], (0, 'logs here', None)),
+        (['git', 'log', 'origin/main..HEAD'], (0, 'logs here', None)),
         (['git', 'checkout', '-b', 'telemetry-tryjob'], (0, None, None)),
-        (['git', 'branch', '--set-upstream-to', 'origin/master'],
+        (['git', 'branch', '--set-upstream-to', 'origin/main'],
          (0, None, None)),
         (['git', 'commit', '-a', '-m', 'bisect config: %s' % platform],
          (0, None, None)),

--- a/src/tools/telemetry/telemetry/internal/platform/win_platform_backend.py
+++ b/src/tools/telemetry/telemetry/internal/platform/win_platform_backend.py
@@ -381,7 +381,7 @@ class WinPlatformBackend(desktop_platform_backend.DesktopPlatformBackend):
     #
     # It seems that intermittently this code manages to find windows
     # that don't belong to Chrome -- for example, the cmd.exe window
-    # running slave.bat on the tryservers. Try to be careful about
+    # running subordinate.bat on the tryservers. Try to be careful about
     # finding only Chrome's windows. This works for both the browser
     # and content_shell.
     #

--- a/src/tools/telemetry/third_party/altgraph/doc/conf.py
+++ b/src/tools/telemetry/third_party/altgraph/doc/conf.py
@@ -44,8 +44,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'altgraph'

--- a/src/tools/telemetry/third_party/gsutilz/gslib/addlhelp/naming.py
+++ b/src/tools/telemetry/third_party/gsutilz/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/src/tools/telemetry/third_party/gsutilz/gslib/commands/notification.py
+++ b/src/tools/telemetry/third_party/gsutilz/gslib/commands/notification.py
@@ -126,7 +126,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://developers.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/src/tools/telemetry/third_party/gsutilz/third_party/apitools/apitools/base/py/batch.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/apitools/apitools/base/py/batch.py
@@ -159,7 +159,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/src/tools/telemetry/third_party/gsutilz/third_party/apitools/run_pylint.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/apitools/run_pylint.py
@@ -103,9 +103,9 @@ def get_files_for_linting(allow_limited=True):
     uses a specific commit or branch (a so-called diff base) to compare
     against for changed files. (This requires ``allow_limited=True``.)
 
-    To speed up linting on Travis pull requests against master, we manually
-    set the diff base to origin/master. We don't do this on non-pull requests
-    since origin/master will be equivalent to the currently checked out code.
+    To speed up linting on Travis pull requests against main, we manually
+    set the diff base to origin/main. We don't do this on non-pull requests
+    since origin/main will be equivalent to the currently checked out code.
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
@@ -122,11 +122,11 @@ def get_files_for_linting(allow_limited=True):
               linted.
     """
     diff_base = None
-    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+    if (os.getenv('TRAVIS_BRANCH') == 'main' and
             os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
-        # In the case of a pull request into master, we want to
-        # diff against HEAD in master.
-        diff_base = 'origin/master'
+        # In the case of a pull request into main, we want to
+        # diff against HEAD in main.
+        diff_base = 'origin/main'
     elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
         remote = os.getenv('GCLOUD_REMOTE_FOR_LINT')

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/emr/connection.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/emr/connection.py
@@ -398,8 +398,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -426,11 +426,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -461,7 +461,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -515,15 +515,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -710,15 +710,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/emr/step.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/kms/layer1.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/opsworks/layer1.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/pyami/bootstrap.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds/__init__.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds/__init__.py
@@ -139,8 +139,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -169,8 +169,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -399,8 +399,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -424,8 +424,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -563,7 +563,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -594,8 +594,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -681,8 +681,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds/dbinstance.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds/dbsnapshot.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds2/layer1.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/rds2/layer1.py
@@ -319,8 +319,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -415,9 +415,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -450,8 +450,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -534,7 +534,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -653,8 +653,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2478,7 +2478,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2606,14 +2606,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2624,7 +2624,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2658,7 +2658,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2810,8 +2810,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/redshift/layer1.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/emr/test_connection.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/emr/test_connection.py
@@ -182,7 +182,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -238,7 +238,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(response.instancegroups[0].name, "Main instance group")
         self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
         self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
@@ -566,7 +566,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -598,7 +598,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.status.state, 'TERMINATED')
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
-        self.assertEqual(response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -836,7 +836,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -853,7 +853,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -871,11 +871,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -903,14 +903,14 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -932,7 +932,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1000,5 +1000,5 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster' },
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/rds/test_connection.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/route53/test_connection.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/src/tools/telemetry/third_party/gsutilz/third_party/crcmod/docs/source/conf.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/src/tools/telemetry/third_party/gsutilz/third_party/oauth2client/docs/conf.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/oauth2client/docs/conf.py
@@ -17,7 +17,7 @@ extensions = [
 ]
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 # General information about the project.
 project = u'oauth2client'

--- a/src/tools/telemetry/third_party/gsutilz/third_party/rsa/doc/conf.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/rsa/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Python-RSA'

--- a/src/tools/telemetry/third_party/gsutilz/third_party/six/documentation/conf.py
+++ b/src/tools/telemetry/third_party/gsutilz/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"

--- a/src/tools/telemetry/third_party/modulegraph/doc/conf.py
+++ b/src/tools/telemetry/third_party/modulegraph/doc/conf.py
@@ -48,8 +48,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'modulegraph'

--- a/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/test_modulegraph.py
+++ b/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/test_modulegraph.py
@@ -606,9 +606,9 @@ class TestModuleGraph (unittest.TestCase):
         script = os.path.join(os.path.dirname(TESTDATA), 'script')
 
         graph = modulegraph.ModuleGraph()
-        master = graph.createNode(modulegraph.Node, 'root')
-        m = graph.run_script(script, master)
-        self.assertEqual(list(graph.get_edges(master)[0])[0], m)
+        main = graph.createNode(modulegraph.Node, 'root')
+        m = graph.run_script(script, main)
+        self.assertEqual(list(graph.get_edges(main)[0])[0], m)
         self.assertEqual(set(graph.get_edges(m)[0]), set([
             graph.findNode('sys'),
             graph.findNode('os'),

--- a/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/distribute-0.6.10/child/namedpkg/slave.py
+++ b/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/distribute-0.6.10/child/namedpkg/slave.py
@@ -1,2 +1,2 @@
-""" slave packages """
+""" subordinate packages """
 import os

--- a/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/distribute-0.6.12/child/namedpkg/slave.py
+++ b/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/distribute-0.6.12/child/namedpkg/slave.py
@@ -1,2 +1,2 @@
-""" slave packages """
+""" subordinate packages """
 import os

--- a/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/setuptools-0.6c9/child/namedpkg/slave.py
+++ b/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/setuptools-0.6c9/child/namedpkg/slave.py
@@ -1,2 +1,2 @@
-""" slave packages """
+""" subordinate packages """
 import os

--- a/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/src/child/namedpkg/slave.py
+++ b/src/tools/telemetry/third_party/modulegraph/modulegraph_tests/testdata/nspkg/src/child/namedpkg/slave.py
@@ -1,2 +1,2 @@
-""" slave packages """
+""" subordinate packages """
 import os

--- a/src/tools/telemetry/third_party/png/png.py
+++ b/src/tools/telemetry/third_party/png/png.py
@@ -50,7 +50,7 @@
 # http://trac.browsershots.org/browser/trunk/pypng/lib/png.py?rev=2885
 
 # Incorporated into pypng by drj on 2009-03-12 from
-# //depot/prj/bangaio/master/code/png.py#67
+# //depot/prj/bangaio/main/code/png.py#67
 
 
 """

--- a/src/tools/telemetry/third_party/pyserial/serial/tools/list_ports_osx.py
+++ b/src/tools/telemetry/third_party/pyserial/serial/tools/list_ports_osx.py
@@ -28,7 +28,7 @@ import re
 iokit = ctypes.cdll.LoadLibrary(ctypes.util.find_library('IOKit'))
 cf = ctypes.cdll.LoadLibrary(ctypes.util.find_library('CoreFoundation'))
 
-kIOMasterPortDefault = ctypes.c_void_p.in_dll(iokit, "kIOMasterPortDefault")
+kIOMainPortDefault = ctypes.c_void_p.in_dll(iokit, "kIOMainPortDefault")
 kCFAllocatorDefault = ctypes.c_void_p.in_dll(cf, "kCFAllocatorDefault")
 
 kCFStringEncodingMacRoman = 0
@@ -155,7 +155,7 @@ def GetIOServicesByType(service_type):
     serial_port_iterator = ctypes.c_void_p()
 
     response = iokit.IOServiceGetMatchingServices(
-        kIOMasterPortDefault,
+        kIOMainPortDefault,
         iokit.IOServiceMatching(service_type),
         ctypes.byref(serial_port_iterator)
     )

--- a/src/tools/telemetry/third_party/typ/typ/arg_parser.py
+++ b/src/tools/telemetry/third_party/typ/typ/arg_parser.py
@@ -96,8 +96,8 @@ class ArgumentParser(argparse.ArgumentParser):
             self.add_argument('--coverage-show-missing', action='store_true',
                               help=('Show missing line ranges in coverage '
                                     'report.'))
-            self.add_argument('--master-name',
-                              help=('Buildbot master name to include in the '
+            self.add_argument('--main-name',
+                              help=('Buildbot main name to include in the '
                                     'uploaded data.'))
             self.add_argument('--metadata', action='append', default=[],
                               help=('Optional key=value metadata that will '
@@ -184,8 +184,8 @@ class ArgumentParser(argparse.ArgumentParser):
                 self._print_message('Error: --builder-name must be specified '
                                     'along with --test-result-server')
                 self.exit_status = 2
-            if not rargs.master_name:
-                self._print_message('Error: --master-name must be specified '
+            if not rargs.main_name:
+                self._print_message('Error: --main-name must be specified '
                                     'along with --test-result-server')
                 self.exit_status = 2
             if not rargs.test_type:

--- a/src/tools/telemetry/third_party/typ/typ/json_results.py
+++ b/src/tools/telemetry/third_party/typ/typ/json_results.py
@@ -104,11 +104,11 @@ def make_full_results(metadata, seconds_since_epoch, all_test_names, results):
     return full_results
 
 
-def make_upload_request(test_results_server, builder, master, testtype,
+def make_upload_request(test_results_server, builder, main, testtype,
                         full_results):
     url = 'http://%s/testfile/upload' % test_results_server
     attrs = [('builder', builder),
-             ('master', master),
+             ('main', main),
              ('testtype', testtype)]
     content_type, data = _encode_multipart_form_data(attrs, full_results)
     return url, content_type, data

--- a/src/tools/telemetry/third_party/typ/typ/runner.py
+++ b/src/tools/telemetry/third_party/typ/typ/runner.py
@@ -612,7 +612,7 @@ class Runner(object):
 
         url, content_type, data = json_results.make_upload_request(
             self.args.test_results_server, self.args.builder_name,
-            self.args.master_name, self.args.test_type,
+            self.args.main_name, self.args.test_type,
             full_results)
 
         try:

--- a/src/tools/telemetry/third_party/typ/typ/tests/json_results_test.py
+++ b/src/tools/telemetry/third_party/typ/typ/tests/json_results_test.py
@@ -24,7 +24,7 @@ class TestMakeUploadRequest(unittest.TestCase):
         results = json_results.ResultSet()
         full_results = json_results.make_full_results([], 0, [], results)
         url, content_type, data = json_results.make_upload_request(
-            'localhost', 'fake_builder_name', 'fake_master', 'fake_test_type',
+            'localhost', 'fake_builder_name', 'fake_main', 'fake_test_type',
             full_results)
 
         self.assertEqual(
@@ -40,9 +40,9 @@ class TestMakeUploadRequest(unittest.TestCase):
              '\r\n'
              'fake_builder_name\r\n'
              '---J-S-O-N-R-E-S-U-L-T-S---B-O-U-N-D-A-R-Y-\r\n'
-             'Content-Disposition: form-data; name="master"\r\n'
+             'Content-Disposition: form-data; name="main"\r\n'
              '\r\n'
-             'fake_master\r\n'
+             'fake_main\r\n'
              '---J-S-O-N-R-E-S-U-L-T-S---B-O-U-N-D-A-R-Y-\r\n'
              'Content-Disposition: form-data; name="testtype"\r\n'
              '\r\n'

--- a/src/tools/telemetry/third_party/typ/typ/tests/main_test.py
+++ b/src/tools/telemetry/third_party/typ/typ/tests/main_test.py
@@ -410,7 +410,7 @@ class TestCli(test_case.MainTestCase):
         self.check(['--test-results-server', 'localhost'], ret=2,
                    out=('Error: --builder-name must be specified '
                         'along with --test-result-server\n'
-                        'Error: --master-name must be specified '
+                        'Error: --main-name must be specified '
                         'along with --test-result-server\n'
                         'Error: --test-type must be specified '
                         'along with --test-result-server\n'), err='')
@@ -552,7 +552,7 @@ class TestCli(test_case.MainTestCase):
         try:
             self.check(['--test-results-server',
                         '%s:%d' % server.server_address,
-                        '--master-name', 'fake_master',
+                        '--main-name', 'fake_main',
                         '--builder-name', 'fake_builder',
                         '--test-type', 'typ_tests',
                         '--metadata', 'foo=bar'],
@@ -577,7 +577,7 @@ class TestCli(test_case.MainTestCase):
         try:
             self.check(['--test-results-server',
                         '%s:%d' % server.server_address,
-                        '--master-name', 'fake_master',
+                        '--main-name', 'fake_main',
                         '--builder-name', 'fake_builder',
                         '--test-type', 'typ_tests',
                         '--metadata', 'foo=bar'],
@@ -592,7 +592,7 @@ class TestCli(test_case.MainTestCase):
 
     def test_test_results_server_not_running(self):
         self.check(['--test-results-server', 'localhost:99999',
-                    '--master-name', 'fake_master',
+                    '--main-name', 'fake_main',
                     '--builder-name', 'fake_builder',
                     '--test-type', 'typ_tests',
                     '--metadata', 'foo=bar'],

--- a/src/tools/telemetry/third_party/webpagereplay/third_party/dns/rdataset.py
+++ b/src/tools/telemetry/third_party/webpagereplay/third_party/dns/rdataset.py
@@ -169,7 +169,7 @@ class Rdataset(dns.set.Set):
 
     def to_text(self, name=None, origin=None, relativize=True,
                 override_rdclass=None, **kw):
-        """Convert the rdataset into DNS master file format.
+        """Convert the rdataset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/src/tools/telemetry/third_party/webpagereplay/third_party/dns/rdtypes/ANY/SOA.py
+++ b/src/tools/telemetry/third_party/webpagereplay/third_party/dns/rdtypes/ANY/SOA.py
@@ -22,7 +22,7 @@ import dns.name
 class SOA(dns.rdata.Rdata):
     """SOA record
 
-    @ivar mname: the SOA MNAME (master name) field
+    @ivar mname: the SOA MNAME (main name) field
     @type mname: dns.name.Name object
     @ivar rname: the SOA RNAME (responsible name) field
     @type rname: dns.name.Name object

--- a/src/tools/telemetry/third_party/webpagereplay/third_party/dns/rrset.py
+++ b/src/tools/telemetry/third_party/webpagereplay/third_party/dns/rrset.py
@@ -84,7 +84,7 @@ class RRset(dns.rdataset.Rdataset):
         return True
 
     def to_text(self, origin=None, relativize=True, **kw):
-        """Convert the RRset into DNS master file format.
+        """Convert the RRset into DNS main file format.
 
         @see: L{dns.name.Name.choose_relativity} for more information
         on how I{origin} and I{relativize} determine the way names

--- a/src/tools/telemetry/third_party/webpagereplay/third_party/dns/tokenizer.py
+++ b/src/tools/telemetry/third_party/webpagereplay/third_party/dns/tokenizer.py
@@ -13,7 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 # OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-"""Tokenize DNS master file format"""
+"""Tokenize DNS main file format"""
 
 import cStringIO
 import sys
@@ -47,7 +47,7 @@ class UngetBufferFull(dns.exception.DNSException):
     pass
 
 class Token(object):
-    """A DNS master file format token.
+    """A DNS main file format token.
 
     @ivar ttype: The token type
     @type ttype: int
@@ -156,7 +156,7 @@ class Token(object):
             raise IndexError
 
 class Tokenizer(object):
-    """A DNS master file format tokenizer.
+    """A DNS main file format tokenizer.
 
     A token is a (type, value) tuple, where I{type} is an int, and
     I{value} is a string.  The valid types are EOF, EOL, WHITESPACE,

--- a/src/tools/telemetry/third_party/webpagereplay/third_party/dns/zone.py
+++ b/src/tools/telemetry/third_party/webpagereplay/third_party/dns/zone.py
@@ -520,8 +520,8 @@ class Zone(object):
             raise NoNS
 
 
-class _MasterReader(object):
-    """Read a DNS master file
+class _MainReader(object):
+    """Read a DNS main file
 
     @ivar tok: The tokenizer
     @type tok: dns.tokenizer.Tokenizer object
@@ -569,7 +569,7 @@ class _MasterReader(object):
                 break
 
     def _rr_line(self):
-        """Process one line from a DNS master file."""
+        """Process one line from a DNS main file."""
         # Name
         if self.current_origin is None:
             raise UnknownOrigin
@@ -642,7 +642,7 @@ class _MasterReader(object):
         rds.add(rd, ttl)
 
     def read(self):
-        """Read a DNS master file and build a zone object.
+        """Read a DNS main file and build a zone object.
 
         @raises dns.zone.NoSOA: No SOA RR was found at the zone origin
         @raises dns.zone.NoNS: No NS RRset was found at the zone origin
@@ -704,7 +704,7 @@ class _MasterReader(object):
                                                            filename)
                         self.current_origin = new_origin
                     else:
-                        raise dns.exception.SyntaxError("Unknown master file directive '" + u + "'")
+                        raise dns.exception.SyntaxError("Unknown main file directive '" + u + "'")
                     continue
                 self.tok.unget(token)
                 self._rr_line()
@@ -721,12 +721,12 @@ class _MasterReader(object):
 def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=False, check_origin=True):
-    """Build a zone object from a master file format string.
+    """Build a zone object from a main file format string.
 
-    @param text: the master file format input
+    @param text: the main file format input
     @type text: string.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.
@@ -755,7 +755,7 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
     if filename is None:
         filename = '<string>'
     tok = dns.tokenizer.Tokenizer(text, filename)
-    reader = _MasterReader(tok, origin, rdclass, relativize, zone_factory,
+    reader = _MainReader(tok, origin, rdclass, relativize, zone_factory,
                            allow_include=allow_include,
                            check_origin=check_origin)
     reader.read()
@@ -764,12 +764,12 @@ def from_text(text, origin = None, rdclass = dns.rdataclass.IN,
 def from_file(f, origin = None, rdclass = dns.rdataclass.IN,
               relativize = True, zone_factory=Zone, filename=None,
               allow_include=True, check_origin=True):
-    """Read a master file and build a zone object.
+    """Read a main file and build a zone object.
 
     @param f: file or string.  If I{f} is a string, it is treated
     as the name of a file to open.
     @param origin: The origin of the zone; if not specified, the first
-    $ORIGIN statement in the master file will determine the origin of the
+    $ORIGIN statement in the main file will determine the origin of the
     zone.
     @type origin: dns.name.Name object or string
     @param rdclass: The zone's rdata class; the default is class IN.


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.